### PR TITLE
Create a wrapper component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10419,6 +10419,12 @@
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
+    "prettier": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "dev": true
+    },
     "pretty-bytes": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "prettier": "^2.2.1"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,14 @@
-import React from 'react';
-import logo from './logo.svg';
-import './App.css';
+import React from "react";
+import logo from "./logo.svg";
+import "./App.css";
+import { MainContentWrapper } from "./components/MainContentWrapper/MainContentWrapper";
 
 function App() {
   return (
     <div className="App">
-      { /* your component goes here to test the rendering! */ }
+      <MainContentWrapper>
+        <h1>Hello World!</h1>
+      </MainContentWrapper>
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import './App.css';
 function App() {
   return (
     <div className="App">
-      <!-- your component goes here to test the rendering! -->
+      { /* your component goes here to test the rendering! */ }
     </div>
   );
 }

--- a/src/components/MainContentWrapper/MainContentWrapper.test.tsx
+++ b/src/components/MainContentWrapper/MainContentWrapper.test.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { MainContentWrapper } from "./MainContentWrapper";
+
+describe("The MainContentWrapper component", () => {
+  it("renders with children elements", () => {
+    render(
+      <MainContentWrapper>
+        <h1>Hello World!</h1>
+      </MainContentWrapper>
+    );
+
+    expect(screen.getByText(/^hello world$/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/MainContentWrapper/MainContentWrapper.test.tsx
+++ b/src/components/MainContentWrapper/MainContentWrapper.test.tsx
@@ -10,6 +10,6 @@ describe("The MainContentWrapper component", () => {
       </MainContentWrapper>
     );
 
-    expect(screen.getByText(/^hello world$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^hello world!$/i)).toBeInTheDocument();
   });
 });

--- a/src/components/MainContentWrapper/MainContentWrapper.tsx
+++ b/src/components/MainContentWrapper/MainContentWrapper.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Container } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+
+const useStyles = makeStyles({
+  mainContent: {
+    maxWidth: 768,
+  },
+});
+
+interface MainContentWrapperProps {
+  /**
+   * Any content that needs to be wrapped
+   */
+  children: JSX.Element | JSX.Element[];
+}
+
+/**
+ * Wraps any children passed to it into a fixed width, centered container
+ *
+ * @param props: MainContentWrapperProps
+ * @returns JSX.Element Wrapped content
+ */
+export const MainContentWrapper: React.FC<MainContentWrapperProps> = (
+  props
+): JSX.Element => {
+  const classes = useStyles();
+
+  return (
+    <Container className={classes.mainContent}>{props.children}</Container>
+  );
+};


### PR DESCRIPTION
- Added a component that wraps any children passed to it into
a centered container with a max width of 768 px. 
- Added a simple test to make sure children elements are being rendered.
- Added Prettier as a dev dependency (may I?). 

The demo of the component is in App.tsx.

Closes Pocket#60.