### PR TITLE
Upgrade to TypeScript 4.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2720,9 +2720,9 @@
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
     },
     "@types/react": {
-      "version": "16.9.53",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.53.tgz",
-      "integrity": "sha512-4nW60Sd4L7+WMXH1D6jCdVftuW7j4Za6zdp6tJ33Rqv0nk1ZAmQKML9ZLD4H0dehA3FZxXR/GM8gXplf82oNGw==",
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.2.tgz",
+      "integrity": "sha512-BzzcAlyDxXl2nANlabtT4thtvbbnhee8hMmH/CcJrISDBVcJS1iOsP1f0OAgSdGE0MsY9tqcrb9YoZcOFv9dbQ==",
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -16529,9 +16529,9 @@
       }
     },
     "typescript": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw=="
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
     "@testing-library/user-event": "^7.1.2",
     "@types/jest": "^24.9.1",
     "@types/node": "^12.19.1",
-    "@types/react": "^16.9.53",
+    "@types/react": "^16.14.2",
     "@types/react-dom": "^16.9.8",
     "@types/react-router-dom": "^5.1.6",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.1",
-    "typescript": "^3.7.5"
+    "typescript": "^4.1.3"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "noFallthroughCasesInSwitch": true
   },
   "include": [


### PR DESCRIPTION
## Goal

In #89, it says that the updated Create React App has TypeScript 4.1. That was not quite correct: it is compatible with 4.1 but the actual dependency is ^3.2, so the 3.7.5 version installed when this project was started was enough and TypeScript was not upgraded.

## Implementation Decisions

Updated TypeScript to the latest version (4.1.3) as well as the `@types/react` package that needed to be updated, too. There are some new features and it also catches extra errors - #106 has a fixup commit for a functional component.