### PR TITLE
Wire up Add Story page 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2163,6 +2163,14 @@
         "react-transition-group": "^4.4.0"
       }
     },
+    "@material-ui/icons": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.11.2.tgz",
+      "integrity": "sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==",
+      "requires": {
+        "@babel/runtime": "^7.4.4"
+      }
+    },
     "@material-ui/lab": {
       "version": "4.0.0-alpha.57",
       "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.57.tgz",
@@ -2346,11 +2354,6 @@
         }
       }
     },
-    "@sheerun/mutationobserver-shim": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
-      "integrity": "sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw=="
-    },
     "@sinonjs/commons": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
@@ -2486,34 +2489,52 @@
       }
     },
     "@testing-library/dom": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-6.16.0.tgz",
-      "integrity": "sha512-lBD88ssxqEfz0wFL6MeUyyWZfV/2cjEZZV3YRpb2IoJRej/4f1jB0TzqIOznTpfR1r34CNesrubxwIlAQ8zgPA==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.29.4.tgz",
+      "integrity": "sha512-CtrJRiSYEfbtNGtEsd78mk1n1v2TUbeABlNIcOCJdDfkN5/JTOwQEbbQpoSRxGqzcWPgStMvJ4mNolSuBRv1NA==",
       "requires": {
-        "@babel/runtime": "^7.8.4",
-        "@sheerun/mutationobserver-shim": "^0.3.2",
-        "@types/testing-library__dom": "^6.12.1",
-        "aria-query": "^4.0.2",
-        "dom-accessibility-api": "^0.3.0",
-        "pretty-format": "^25.1.0",
-        "wait-for-expect": "^3.0.2"
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^4.2.2",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.4",
+        "lz-string": "^1.4.4",
+        "pretty-format": "^26.6.2"
       },
       "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
         "@jest/types": {
-          "version": "25.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
-          "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^1.1.1",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
             "@types/yargs": "^15.0.0",
-            "chalk": "^3.0.0"
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/istanbul-reports": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+          "requires": {
+            "@types/istanbul-lib-report": "*"
           }
         },
         "@types/yargs": {
-          "version": "15.0.9",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
-          "integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
+          "version": "15.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.12.tgz",
+          "integrity": "sha512-f+fD/fQAo3BCbCDlrUpznF1A5Zp9rB0noS5vnoormHSIPFKL0Z2DcUJ3Gxp5ytH4uLRNxy7AwYUC9exZzqGMAw==",
           "requires": {
             "@types/yargs-parser": "*"
           }
@@ -2523,6 +2544,82 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
         },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "pretty-format": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+          "requires": {
+            "@jest/types": "^26.6.2",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^17.0.1"
+          }
+        },
+        "react-is": {
+          "version": "17.0.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+          "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@testing-library/jest-dom": {
+      "version": "5.11.9",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.11.9.tgz",
+      "integrity": "sha512-Mn2gnA9d1wStlAIT2NU8J15LNob0YFBVjs2aEQ3j8rsfRQo+lAs7/ui1i2TGaJjapLmuNPLTsrm+nPjmZDwpcQ==",
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@types/testing-library__jest-dom": "^5.9.1",
+        "aria-query": "^4.2.2",
+        "chalk": "^3.0.0",
+        "css": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2553,20 +2650,28 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
+        "css": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+          "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+          "requires": {
+            "inherits": "^2.0.4",
+            "source-map": "^0.6.1",
+            "source-map-resolve": "^0.6.0"
+          }
+        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
-        "pretty-format": {
-          "version": "25.5.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
-          "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+        "source-map-resolve": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+          "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
           "requires": {
-            "@jest/types": "^25.5.0",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^4.0.0",
-            "react-is": "^16.12.0"
+            "atob": "^2.1.2",
+            "decode-uri-component": "^0.2.0"
           }
         },
         "supports-color": {
@@ -2579,41 +2684,52 @@
         }
       }
     },
-    "@testing-library/jest-dom": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-4.2.4.tgz",
-      "integrity": "sha512-j31Bn0rQo12fhCWOUWy9fl7wtqkp7In/YP2p5ZFyRuiiB9Qs3g+hS4gAmDWONbAHcRmVooNJ5eOHQDCOmUFXHg==",
-      "requires": {
-        "@babel/runtime": "^7.5.1",
-        "chalk": "^2.4.1",
-        "css": "^2.2.3",
-        "css.escape": "^1.5.1",
-        "jest-diff": "^24.0.0",
-        "jest-matcher-utils": "^24.0.0",
-        "lodash": "^4.17.11",
-        "pretty-format": "^24.0.0",
-        "redent": "^3.0.0"
-      }
-    },
     "@testing-library/react": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-9.5.0.tgz",
-      "integrity": "sha512-di1b+D0p+rfeboHO5W7gTVeZDIK5+maEgstrZbWZSSvxDyfDRkkyBE1AJR5Psd6doNldluXlCWqXriUfqu/9Qg==",
+      "version": "11.2.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.3.tgz",
+      "integrity": "sha512-BirBUGPkTW28ULuCwIbYo0y2+0aavHczBT6N9r3LrsswEW3pg25l1wgoE7I8QBIy1upXWkwKpYdWY7NYYP0Bxw==",
       "requires": {
-        "@babel/runtime": "^7.8.4",
-        "@testing-library/dom": "^6.15.0",
-        "@types/testing-library__react": "^9.1.2"
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^7.28.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     },
     "@testing-library/user-event": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-7.2.1.tgz",
-      "integrity": "sha512-oZ0Ib5I4Z2pUEcoo95cT1cr6slco9WY7yiPpG+RGNkj8YcYgJnM7pXmYmorNOReh8MIGcKSqXyeGjxnr8YiZbA=="
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.6.0.tgz",
+      "integrity": "sha512-FNEH/HLmOk5GO70I52tKjs7WvGYckeE/SrnLX/ip7z2IGbffyd5zOUM1tZ10vsTphqm+VbDFI0oaXu0wcfQsAQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
     },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
       "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA=="
+    },
+    "@types/aria-query": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.1.tgz",
+      "integrity": "sha512-S6oPal772qJZHoRZLFc/XoZW2gFvwXusYUmXPXkgxJLuEk2vOt7jc4Yo6z/vtI0EBkbPBVrJJ0B+prLIKiWqHg=="
     },
     "@types/babel__core": {
       "version": "7.1.12",
@@ -2835,102 +2951,12 @@
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.6.tgz",
       "integrity": "sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA=="
     },
-    "@types/testing-library__dom": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@types/testing-library__dom/-/testing-library__dom-6.14.0.tgz",
-      "integrity": "sha512-sMl7OSv0AvMOqn1UJ6j1unPMIHRXen0Ita1ujnMX912rrOcawe4f7wu0Zt9GIQhBhJvH2BaibqFgQ3lP+Pj2hA==",
+    "@types/testing-library__jest-dom": {
+      "version": "5.9.5",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.5.tgz",
+      "integrity": "sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==",
       "requires": {
-        "pretty-format": "^24.3.0"
-      }
-    },
-    "@types/testing-library__react": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/@types/testing-library__react/-/testing-library__react-9.1.3.tgz",
-      "integrity": "sha512-iCdNPKU3IsYwRK9JieSYAiX0+aYDXOGAmrC/3/M7AqqSDKnWWVv07X+Zk1uFSL7cMTUYzv4lQRfohucEocn5/w==",
-      "requires": {
-        "@types/react-dom": "*",
-        "@types/testing-library__dom": "*",
-        "pretty-format": "^25.1.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "25.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
-          "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^1.1.1",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^3.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "15.0.9",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.9.tgz",
-          "integrity": "sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==",
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-        },
-        "pretty-format": {
-          "version": "25.5.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
-          "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
-          "requires": {
-            "@jest/types": "^25.5.0",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^4.0.0",
-            "react-is": "^16.12.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
+        "@types/jest": "*"
       }
     },
     "@types/uglify-js": {
@@ -5815,9 +5841,9 @@
       }
     },
     "dom-accessibility-api": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.3.0.tgz",
-      "integrity": "sha512-PzwHEmsRP3IGY4gv/Ug+rMeaTIyTJvadCb+ujYXYeIylbHJezIyNToe8KfEgHTCEYyC+/bUghYOGg8yMGlZ6vA=="
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz",
+      "integrity": "sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ=="
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -10120,17 +10146,6 @@
         }
       }
     },
-    "jest-matcher-utils": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
-      "integrity": "sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==",
-      "requires": {
-        "chalk": "^2.0.1",
-        "jest-diff": "^24.9.0",
-        "jest-get-type": "^24.9.0",
-        "pretty-format": "^24.9.0"
-      }
-    },
     "jest-message-util": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.6.2.tgz",
@@ -11801,6 +11816,11 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY="
     },
     "magic-string": {
       "version": "0.25.7",
@@ -14391,6 +14411,11 @@
       "version": "6.0.8",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.8.tgz",
       "integrity": "sha512-HvPuUQnLp5H7TouGq3kzBeioJmXms1wHy9EGjz2OURWBp4qZO6AfGEcnxts1D/CbwPLRAgTMPCEgYhA3sEM4vw=="
+    },
+    "react-hook-form": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-6.14.1.tgz",
+      "integrity": "sha512-Bf2fWcL2F34hUUqrx1rpgZ8ZErQ4/DvrPs6Je+lUYL59km8PXIQqyCTz/NbggC1RQUj7rChSmTx6eFap+mCttw=="
     },
     "react-is": {
       "version": "16.13.1",
@@ -17117,11 +17142,6 @@
       "requires": {
         "xml-name-validator": "^3.0.0"
       }
-    },
-    "wait-for-expect": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-3.0.2.tgz",
-      "integrity": "sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag=="
     },
     "walker": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "dependencies": {
     "@apollo/client": "^3.3.6",
     "@material-ui/core": "^4.11.0",
+    "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.57",
-    "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/react": "^9.3.2",
-    "@testing-library/user-event": "^7.1.2",
+    "@testing-library/jest-dom": "^5.11.9",
+    "@testing-library/react": "^11.2.3",
+    "@testing-library/user-event": "^12.6.0",
     "@types/jest": "^24.9.1",
     "@types/node": "^12.19.1",
     "@types/react": "^16.14.2",
@@ -19,6 +20,7 @@
     "graphql": "^15.4.0",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
+    "react-hook-form": "^6.14.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.1",
     "typescript": "^4.1.3"

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -7,8 +7,6 @@ import {
   FeedVariables,
 } from './services/queries/getCurrentFeed';
 import App from './App';
-import { act } from 'react-dom/test-utils';
-import { ApolloError } from '@apollo/client';
 
 describe('The App', () => {
   const mocks = [
@@ -37,47 +35,5 @@ describe('The App', () => {
     );
 
     expect(screen.getByText('Loading...')).toBeInTheDocument();
-  });
-
-  it('displays an error if the API call was unsuccessful', async () => {
-    const mocksWithError = [
-      {
-        request: {
-          query: getCurrentFeed,
-          variables: {
-            name: 'en-US',
-          } as FeedVariables,
-        },
-        error: new ApolloError({
-          networkError: new Error('An error occurred.'),
-        }),
-      },
-    ];
-
-    render(
-      <MockedProvider mocks={mocksWithError} addTypename={false}>
-        <App />
-      </MockedProvider>
-    );
-
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-    });
-
-    expect(screen.getByText(/network error/i)).toBeInTheDocument();
-  });
-
-  xit('displays the page successfully', async () => {
-    const { debug } = render(
-      <MockedProvider mocks={mocks} addTypename={false}>
-        <App />
-      </MockedProvider>
-    );
-
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 3000));
-    });
-    debug();
-    expect(screen.getByText(/^lloading.../i)).toBeInTheDocument();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,10 +18,11 @@ import { MainContentWrapper } from './components/MainContentWrapper/MainContentW
 import { HandleApiResponse } from './components/HandleApiResponse/HandleApiResponse';
 
 // pages
-import { AddStoryPage } from './pages/AddStoryPage';
+import { AddStoryPage } from './pages/AddStoryPage/AddStoryPage';
 import { HomePage } from './pages/HomePage';
 import { NewTabPage } from './pages/NewTabPage/NewTabPage';
 import { ProspectsPage } from './pages/ProspectsPage/ProspectsPage';
+import { EditAndApproveStoryPage } from './pages/EditAndApproveStoryPage/EditAndApproveStoryPage';
 
 function App(): JSX.Element {
   /**
@@ -82,11 +83,20 @@ function App(): JSX.Element {
                   >
                     <ProspectsPage feed={currentFeed} />
                   </Route>
-                  <Route path="/:feed/prospects/article/add/">
-                    <AddStoryPage />
+                  <Route exact path="/:feed/prospects/article/add/">
+                    <AddStoryPage feed={currentFeed} />
+                  </Route>
+                  <Route
+                    exact
+                    path="/:feed/prospects/article/edit-and-approve/:articleid/"
+                  >
+                    <EditAndApproveStoryPage />
                   </Route>
                   <Route path="/:feed/newtab/">
                     <NewTabPage />
+                  </Route>
+                  <Route path="*">
+                    <HomePage feed={currentFeed} />
                   </Route>
                 </Switch>
               </MainContentWrapper>

--- a/src/components/AddStory/AddStory.test.tsx
+++ b/src/components/AddStory/AddStory.test.tsx
@@ -1,33 +1,102 @@
 import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
 import { AddStory } from './AddStory';
 
 describe('The AddStory component', () => {
-  let input: any;
+  let mockSubmit: any;
+  let testUrl: any;
 
   beforeEach(() => {
-    render(<AddStory />);
-    input = screen.getByLabelText(/^Story URL$/i) as HTMLInputElement;
+    mockSubmit = jest.fn((url) => {
+      return Promise.resolve({ url });
+    });
+
+    testUrl = 'https://www.mozilla.org/en-US/';
   });
 
-  it('renders successfully', () => {
+  it('renders successfully', async () => {
+    await waitFor(() => {
+      render(<AddStory onSubmit={mockSubmit} />);
+    });
+
+    const input = screen.getByLabelText(/story url/i) as HTMLInputElement;
     expect(input).toBeInTheDocument();
 
-    const buttons = screen.getAllByRole('button');
-    expect(buttons.length).toEqual(2);
-
-    buttons.forEach((button) => {
-      expect(button).toBeInTheDocument();
-    });
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
   });
 
-  it('updates the URL on change', () => {
-    const testUrl = 'https://www.mozilla.org/en-US/';
+  it('updates the URL on change', async () => {
+    await waitFor(() => {
+      render(<AddStory onSubmit={mockSubmit} />);
+    });
+
+    const input = screen.getByLabelText(/story url/i) as HTMLInputElement;
 
     fireEvent.change(input, {
       target: { value: testUrl },
     });
 
     expect(input).toHaveValue(testUrl);
+  });
+
+  it('should display required error when no URL is supplied', async () => {
+    await waitFor(() => {
+      render(<AddStory onSubmit={mockSubmit} />);
+    });
+
+    await waitFor(() => {
+      fireEvent.submit(screen.getByRole('form'));
+    });
+
+    expect(await screen.getByText(/please enter a url/i)).toBeInTheDocument();
+    expect(mockSubmit).not.toBeCalled();
+  });
+
+  it('should display matching error when URL is malformed', async () => {
+    await waitFor(() => {
+      render(<AddStory onSubmit={mockSubmit} />);
+    });
+
+    await waitFor(() => {
+      const input = screen.getByLabelText(/story url/i) as HTMLInputElement;
+
+      fireEvent.input(input, {
+        target: {
+          value: 'test link',
+        },
+      });
+
+      fireEvent.submit(screen.getByRole('form'));
+    });
+
+    expect(
+      await screen.getByText(/please enter a valid url/i)
+    ).toBeInTheDocument();
+    expect(mockSubmit).not.toBeCalled();
+  });
+
+  it('should proceed with form submission if URL is valid', async () => {
+    await waitFor(() => {
+      render(<AddStory onSubmit={mockSubmit} />);
+    });
+
+    await waitFor(() => {
+      const input = screen.getByLabelText(/story url/i) as HTMLInputElement;
+
+      fireEvent.input(input, {
+        target: {
+          value: testUrl,
+        },
+      });
+
+      fireEvent.submit(screen.getByRole('form'));
+    });
+
+    expect(screen.queryByText(/please enter a url/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/please enter a valid url/i)
+    ).not.toBeInTheDocument();
+    expect(mockSubmit).toBeCalled();
   });
 });

--- a/src/components/AddStory/AddStory.tsx
+++ b/src/components/AddStory/AddStory.tsx
@@ -1,64 +1,68 @@
-import React, { useState } from 'react';
-import {
-  Button,
-  TextField,
-  Divider,
-  Box,
-  Typography,
-  Grid,
-} from '@material-ui/core';
+import React from 'react';
+import { Box, Divider, Button, TextField } from '@material-ui/core';
+import { useForm } from 'react-hook-form';
 
-import { makeStyles, Theme } from '@material-ui/core/styles';
+interface AddStoryProps {
+  /**
+   * The submit handler passed to this component receives form data as a prop.
+   *
+   * @param data
+   */
+  onSubmit: (data: { url: string }) => void;
+}
 
-const useStyles = makeStyles((theme: Theme) => ({
-  alignRight: {
-    textAlign: 'right',
-  },
-}));
+export interface AddStoryFormData {
+  /**
+   * The URL of the story to be parsed.
+   */
+  url: string;
+}
 
-export const AddStory = (): JSX.Element => {
-  const classes = useStyles();
-
-  const [url, setUrl] = useState('');
-
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setUrl(event.target.value);
-  };
+/**
+ * Add Story form. Validates the URL of the story to be added and displays any
+ * validation errors to the user. Once successful, passes validated data
+ * to the supplied submit handler for further processing.
+ *
+ * @param props
+ */
+export const AddStory: React.FC<AddStoryProps> = (props): JSX.Element => {
+  const { onSubmit } = props;
+  const { handleSubmit, register, errors } = useForm<AddStoryFormData>();
 
   return (
-    <>
-      <Grid container spacing={3}>
-        <Grid item xs={8}>
-          <Typography variant="h4" component="h1" align="left">
-            Add Story
-          </Typography>
-        </Grid>
-        <Grid item xs={4} className={classes.alignRight}>
-          <Button variant="outlined">Cancel</Button>
-        </Grid>
-      </Grid>
-      <form>
-        <TextField
-          id="add-story"
-          label="Story URL"
-          placeholder="Placeholder"
-          helperText="Edit & approve another story by changing this URL"
-          fullWidth
-          margin="normal"
-          InputLabelProps={{
-            shrink: true,
-          }}
-          variant="outlined"
-          value={url}
-          onChange={handleChange}
-        />
-        <Divider />
-        <Box display="flex" justifyContent="flex-end" mt="1rem">
-          <Button color="primary" variant="contained">
-            Parse
-          </Button>
-        </Box>
-      </form>
-    </>
+    <form name="add-story" onSubmit={handleSubmit(onSubmit)}>
+      <TextField
+        id="url"
+        inputRef={register({
+          required: { value: true, message: 'Please enter a URL' },
+          pattern: {
+            // regex credit goes to https://gist.github.com/dperini/729294
+            value: /^(?:(?:(?:https?|ftp):)?\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z0-9\u00a1-\uffff][a-z0-9\u00a1-\uffff_-]{0,62})?[a-z0-9\u00a1-\uffff]\.)+(?:[a-z\u00a1-\uffff]{2,}\.?))(?::\d{2,5})?(?:[/?#]\S*)?$/i,
+            message: 'Please enter a valid URL',
+          },
+        })}
+        error={!!errors.url}
+        name="url"
+        label="Story URL"
+        placeholder="Placeholder"
+        helperText={
+          errors.url
+            ? errors.url.message
+            : 'Edit & approve another story by changing this URL'
+        }
+        fullWidth
+        margin="normal"
+        InputLabelProps={{
+          shrink: true,
+        }}
+        variant="outlined"
+      />
+      <Divider />
+      <Box display="flex" justifyContent="flex-end" mt="1rem">
+        <Button color="primary" variant="contained" type="submit">
+          Parse
+        </Button>
+      </Box>
+    </form>
   );
 };

--- a/src/components/HandleApiResponse/HandleApiResponse.test.tsx
+++ b/src/components/HandleApiResponse/HandleApiResponse.test.tsx
@@ -40,6 +40,6 @@ describe('The HandleApiResponse component', () => {
       <HandleApiResponse loading={false} error={undefined} />
     );
 
-    expect(container).toBeEmpty();
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/src/components/HandleApiResponse/HandleApiResponse.tsx
+++ b/src/components/HandleApiResponse/HandleApiResponse.tsx
@@ -56,9 +56,8 @@ interface HandleApiResponseProps {
 }
 
 /**
- * A wrapper component that cycles through the various states
- * of the API response before handing over to child components to display
- * the retrieved data.
+ * A wrapper component that displays a loading component while the API call
+ * is in progress and any errors if the API call was unsuccessful.
  *
  * @param props
  */

--- a/src/components/HandleApiResponse/HandleApiResponse.tsx
+++ b/src/components/HandleApiResponse/HandleApiResponse.tsx
@@ -1,8 +1,15 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { ApolloError } from '@apollo/client';
 import { makeStyles } from '@material-ui/core/styles';
-import { Box, CircularProgress } from '@material-ui/core';
-import { Alert, AlertTitle } from '@material-ui/lab';
+import {
+  Box,
+  CircularProgress,
+  Collapse,
+  Grow,
+  IconButton,
+} from '@material-ui/core';
+import { Alert } from '@material-ui/lab';
+import CloseIcon from '@material-ui/icons/Close';
 
 import { Modal } from '../Modal/Modal';
 
@@ -32,6 +39,12 @@ interface HandleApiResponseProps {
   error?: ApolloError;
 
   /**
+   * Whether the error alert box can be closed
+   */
+
+  errorIsDismissible?: boolean;
+
+  /**
    * Whether to show the loading component in a modal or inline
    */
   useModal?: boolean;
@@ -43,8 +56,9 @@ interface HandleApiResponseProps {
 }
 
 /**
- * A wrapper component that displays a loading component while the API call
- * is in progress and any errors if the API call was unsuccessful.
+ * A wrapper component that cycles through the various states
+ * of the API response before handing over to child components to display
+ * the retrieved data.
  *
  * @param props
  */
@@ -53,22 +67,32 @@ export const HandleApiResponse: React.FC<HandleApiResponseProps> = (
 ): JSX.Element | null => {
   const classes = useStyles();
 
-  const { loading, error, useModal = false, loadingText = '' } = props;
+  const [isErrorVisible, setIsErrorVisible] = useState(true);
+
+  const {
+    loading,
+    error,
+    errorIsDismissible = true,
+    useModal = false,
+    loadingText = '',
+  } = props;
 
   if (loading) {
     return useModal ? (
       <Modal content={loadingText} open={true} />
     ) : (
-      <Box
-        flex="1"
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        textAlign="center"
-        p={7}
-      >
-        <CircularProgress /> {loadingText}
-      </Box>
+      <Grow in={loading} timeout={1000}>
+        <Box
+          flex="1"
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          textAlign="center"
+          p={7}
+        >
+          <CircularProgress /> {loadingText}
+        </Box>
+      </Grow>
     );
   }
 
@@ -79,8 +103,7 @@ export const HandleApiResponse: React.FC<HandleApiResponseProps> = (
 
     if (graphQLErrors)
       messages = graphQLErrors.map(
-        ({ message, locations, path }) =>
-          `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`
+        ({ message }) => `[GraphQL error]: ${message}`
       );
 
     if (networkError) {
@@ -92,12 +115,31 @@ export const HandleApiResponse: React.FC<HandleApiResponseProps> = (
     }
 
     return (
-      <Box my={3}>
-        <Alert severity="error" variant="filled" className={classes.root}>
-          <AlertTitle className={classes.title}>Error</AlertTitle>
-          {messages}
-        </Alert>
-      </Box>
+      <Collapse in={isErrorVisible}>
+        <Box my={3}>
+          <Alert
+            action={
+              errorIsDismissible ? (
+                <IconButton
+                  aria-label="close"
+                  color="inherit"
+                  size="small"
+                  onClick={() => {
+                    setIsErrorVisible(false);
+                  }}
+                >
+                  <CloseIcon fontSize="inherit" />
+                </IconButton>
+              ) : undefined
+            }
+            severity="error"
+            variant="filled"
+            className={classes.root}
+          >
+            {messages}
+          </Alert>
+        </Box>
+      </Collapse>
     );
   }
 

--- a/src/pages/AddStoryPage.tsx
+++ b/src/pages/AddStoryPage.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-import { AddStory } from '../components/AddStory/AddStory';
-
-export const AddStoryPage = (): JSX.Element => {
-  return <AddStory />;
-};

--- a/src/pages/AddStoryPage/AddStoryPage.test.tsx
+++ b/src/pages/AddStoryPage/AddStoryPage.test.tsx
@@ -1,0 +1,165 @@
+import React from 'react';
+import { Router } from 'react-router';
+import { createMemoryHistory } from 'history';
+import { MockedProvider } from '@apollo/client/testing';
+import { ApolloError } from '@apollo/client';
+import { render, fireEvent, screen, act } from '@testing-library/react';
+
+import { AddStoryPage } from './AddStoryPage';
+import { Feed } from '../../services/types/Feed';
+import {
+  createProspectByUrl,
+  CreateProspectData,
+  CreateProspectVariables,
+} from '../../services/mutations/createProspectByUrl';
+
+describe('The AddStory page', () => {
+  let mockFeed: Feed;
+  let testUrl: string;
+
+  beforeEach(() => {
+    mockFeed = { id: 'abc', name: 'en-US' };
+    testUrl = 'https://www.mozilla.org/en-US/';
+  });
+
+  it('shows an error if the API call was unsuccessful', async () => {
+    const mocksWithError = [
+      {
+        request: {
+          query: createProspectByUrl,
+          variables: {
+            feedId: mockFeed.id,
+            url: testUrl,
+          } as CreateProspectVariables,
+        },
+        error: new ApolloError({
+          networkError: new Error('An error occurred.'),
+        }),
+      },
+    ];
+
+    render(
+      <MockedProvider mocks={mocksWithError} addTypename={false}>
+        <AddStoryPage feed={mockFeed} />
+      </MockedProvider>
+    );
+
+    // fill out the form
+    const input = screen.getByLabelText(/story url/i) as HTMLInputElement;
+    fireEvent.change(input, {
+      target: { value: testUrl },
+    });
+
+    // submit it
+    fireEvent.click(screen.getByText(/parse/i));
+
+    // wait for the API
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // get response
+    expect(screen.getByText(/an error occurred/i)).toBeInTheDocument();
+  });
+
+  it('redirects to Edit & Approve form if prospect was successfully added', async () => {
+    const newProspectId = 'abcdefg-jkl-mnop';
+
+    const mocks = [
+      {
+        request: {
+          query: createProspectByUrl,
+          variables: {
+            feedId: mockFeed.id,
+            url: testUrl,
+          } as CreateProspectVariables,
+        },
+        result: {
+          data: {
+            prospect: {
+              id: newProspectId,
+            },
+          } as CreateProspectData,
+        },
+      },
+    ];
+
+    const history = createMemoryHistory({
+      initialEntries: ['/en-US/prospects/article/add/'],
+      initialIndex: 0,
+    });
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <Router history={history}>
+          <AddStoryPage feed={mockFeed} />
+        </Router>
+      </MockedProvider>
+    );
+
+    // fill out the form
+    const input = screen.getByLabelText(/story url/i) as HTMLInputElement;
+    fireEvent.change(input, {
+      target: { value: testUrl },
+    });
+
+    // submit it
+    fireEvent.click(screen.getByText(/parse/i));
+
+    // wait for the API
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // redirect to the Edit & Approve form on success
+    expect(history.location.pathname).toEqual(
+      `/en-US/prospects/article/edit-and-approve/${newProspectId}/`
+    );
+  });
+
+  describe('when Cancel button is clicked', () => {
+    it('goes back to the previous page', () => {
+      const history = createMemoryHistory({
+        initialEntries: [
+          '/en-US/newtab/live/',
+          '/en-US/prospects/',
+          '/en-US/prospects/article/add/',
+        ],
+        initialIndex: 2,
+      });
+
+      render(
+        <MockedProvider>
+          <Router history={history}>
+            <AddStoryPage feed={mockFeed} />
+          </Router>
+        </MockedProvider>
+      );
+
+      const cancelButton = screen.getByText('Cancel');
+      fireEvent.click(cancelButton);
+
+      expect(history.location.pathname).toEqual('/en-US/prospects/');
+    });
+
+    it('goes to home page if there is no browsing history', () => {
+      const history = createMemoryHistory({
+        initialEntries: ['/en-US/prospects/article/add/'],
+        initialIndex: 0,
+      });
+
+      render(
+        <MockedProvider>
+          <Router history={history}>
+            <AddStoryPage feed={mockFeed} />
+          </Router>
+        </MockedProvider>
+      );
+
+      const cancelButton = screen.getByText('Cancel');
+      fireEvent.click(cancelButton);
+
+      expect(history.location.pathname).toEqual('/');
+    });
+  });
+});

--- a/src/pages/AddStoryPage/AddStoryPage.tsx
+++ b/src/pages/AddStoryPage/AddStoryPage.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { useMutation } from '@apollo/client';
+import { Box, Grid, Typography } from '@material-ui/core';
+import { useHistory } from 'react-router-dom';
+import { makeStyles, Theme } from '@material-ui/core/styles';
+
+import {
+  createProspectByUrl,
+  CreateProspectData,
+  CreateProspectVariables,
+} from '../../services/mutations/createProspectByUrl';
+import { Feed } from '../../services/types/Feed';
+import { AddStory, AddStoryFormData } from '../../components/AddStory/AddStory';
+import { Button } from '../../components/Button/Button';
+import { HandleApiResponse } from '../../components/HandleApiResponse/HandleApiResponse';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  alignRight: {
+    textAlign: 'right',
+  },
+}));
+
+/**
+ * Add Story page
+ *
+ * On this page you can submit a URL and expect it to be added
+ * to the list of prospects on the Prospects tab.
+ */
+export const AddStoryPage = ({
+  feed,
+}: {
+  feed: Feed | undefined;
+}): JSX.Element => {
+  const classes = useStyles();
+  const history = useHistory();
+
+  /**
+   * Go back to previous page if there is anything to go back to,
+   * otherwise go to home page.
+   */
+  const handleCancelAction = () => {
+    history.length > 1 ? history.goBack() : history.push('/');
+  };
+
+  // prepare mutation
+  const [createProspectMutation, { loading, error }] = useMutation<
+    CreateProspectData,
+    CreateProspectVariables
+  >(createProspectByUrl);
+
+  /**
+   * Collect form data and send it to the API.
+   *
+   * @param data
+   */
+  const handleFormSubmit = (data: AddStoryFormData) => {
+    const url = data.url;
+
+    createProspectMutation({
+      variables: {
+        feedId: feed?.id ?? 'none',
+        url,
+      },
+    })
+      .then((data) => {
+        // Success! Move on to the full edit form
+        history.push(
+          `/${feed?.name}/prospects/article/edit-and-approve/${data.data?.prospect.id}/`,
+          { prospect: data.data?.prospect }
+        );
+      })
+      .catch((error) => {
+        // Do nothing. The errors are already destructured and shown on the frontend
+        // Yet if a catch() statement is missing an "Unhandled rejection" will break through
+      });
+  };
+
+  return (
+    <>
+      <Box mb={4}>
+        <Grid container spacing={3}>
+          <Grid item xs={8}>
+            <Typography variant="h4" component="h1" align="left">
+              Add Story
+            </Typography>
+          </Grid>
+          <Grid item xs={4} className={classes.alignRight}>
+            <Button buttonType="hollow-neutral" onClick={handleCancelAction}>
+              Cancel
+            </Button>
+          </Grid>
+        </Grid>
+      </Box>
+      <HandleApiResponse loading={loading} error={error} />
+      <AddStory onSubmit={handleFormSubmit} />
+    </>
+  );
+};

--- a/src/pages/EditAndApproveStoryPage/EditAndApproveStoryPage.tsx
+++ b/src/pages/EditAndApproveStoryPage/EditAndApproveStoryPage.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Prospect } from '../../services/types/Prospect';
+import { useLocation } from 'react-router-dom';
+
+interface EditAndApproveStoryPageProps {
+  prospect?: Prospect;
+}
+
+export const EditAndApproveStoryPage: React.FC<EditAndApproveStoryPageProps> = (
+  props
+): JSX.Element => {
+  /**
+   * If a Prospect object was passed to the page from one of the other app pages,
+   * let's extract it from the routing.
+   */
+  const location = useLocation<{ prospect?: Prospect }>();
+
+  // Use the variable or get a TypeScript error.
+  // To be replaced with actual logic for this page.
+  console.log(location.state.prospect);
+
+  return <h1>Edit & Approve</h1>;
+};

--- a/src/pages/ProspectsPage/ProspectsPage.test.tsx
+++ b/src/pages/ProspectsPage/ProspectsPage.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Router } from 'react-router';
 import { createMemoryHistory } from 'history';
 import { MockedProvider } from '@apollo/client/testing';
-import { render, screen, act, within } from '@testing-library/react';
+import { render, screen, act, within, waitFor } from '@testing-library/react';
 
 import { ProspectsPage } from './ProspectsPage';
 import { Feed } from '../../services/types/Feed';
@@ -20,18 +20,19 @@ describe('The Prospects page', () => {
     mockFeed = { id: 'abc', name: 'en-US' };
   });
 
-  xit('renders with four tabs', () => {
+  it('renders with four tabs', async () => {
     const history = createMemoryHistory({
       initialEntries: ['/en-US/prospects/'],
     });
-
-    render(
-      <MockedProvider>
-        <Router history={history}>
-          <ProspectsPage feed={mockFeed} />
-        </Router>
-      </MockedProvider>
-    );
+    await waitFor(() => {
+      render(
+        <MockedProvider>
+          <Router history={history}>
+            <ProspectsPage feed={mockFeed} />
+          </Router>
+        </MockedProvider>
+      );
+    });
 
     const tabNavigation = screen.getByRole('tablist');
     const tabs = within(tabNavigation).getAllByRole('tab');
@@ -90,13 +91,16 @@ describe('The Prospects page', () => {
     const history = createMemoryHistory({
       initialEntries: ['/en-US/prospects/'],
     });
-    render(
-      <MockedProvider mocks={mocks} addTypename={false}>
-        <Router history={history}>
-          <ProspectsPage feed={mockFeed} />
-        </Router>
-      </MockedProvider>
-    );
+
+    await waitFor(() => {
+      render(
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <Router history={history}>
+            <ProspectsPage feed={mockFeed} />
+          </Router>
+        </MockedProvider>
+      );
+    });
 
     // wait for the mock API call to complete
     await act(async () => {

--- a/src/services/mutations/createProspectByUrl.ts
+++ b/src/services/mutations/createProspectByUrl.ts
@@ -1,0 +1,24 @@
+import { gql } from '@apollo/client';
+import { ProspectData } from '../fragments/ProspectData';
+import { Prospect } from '../types/Prospect';
+
+export interface CreateProspectData {
+  prospect: Prospect;
+}
+
+export interface CreateProspectVariables {
+  feedId: string;
+  url: string;
+}
+
+/**
+ * Add a prospect by supplying the feed id, source name and the article URL
+ */
+export const createProspectByUrl = gql`
+  mutation createProspectByUrl($feedId: ID!, $url: String!) {
+    prospect: createProspectByUrl(input: { feedId: $feedId, url: $url }) {
+      ...ProspectData
+    }
+  }
+  ${ProspectData}
+`;


### PR DESCRIPTION
## Goal

To be able to add a prospect from the Add Story page by supplying the URL of an article.
 
## Implementation Decisions

- Added @material-ui/icons (needed a closing icon to make errors dismissible).

- Updated tests: removed Apollo-related tests from App.test.tsx, added tests for AddStoryPage.

Note that on success the page redirects to the Edit & Approve page that is not implemented yet, so if everything is fine you will see a blank page and just the URL will be updated to the path for that page, i.e. `/en-US/prospects/article/edit-and-approve/abcd-1234-efg-567/`, where `abcd...` is the actual prospect ID that comes back from the API. I thought about putting up something temporary but then decided not to as that way I'll be able to submit a completely independent PR for the Edit & Approve page and deal with minimal merge conflicts later on.

Closes #97.