### PR TITLE
Follow-up fixes and improvements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,8 +20,8 @@ import { HandleApiResponse } from './components/HandleApiResponse/HandleApiRespo
 // pages
 import { AddStoryPage } from './pages/AddStoryPage';
 import { HomePage } from './pages/HomePage';
-import { NewTabLivePage } from './pages/newtab/NewTabLivePage';
-import { ProspectsListPage } from './pages/prospects/ProspectsListPage';
+import { NewTabPage } from './pages/NewTabPage/NewTabPage';
+import { ProspectsPage } from './pages/ProspectsPage/ProspectsPage';
 
 function App(): JSX.Element {
   /**
@@ -57,36 +57,41 @@ function App(): JSX.Element {
     <ApolloProvider client={client}>
       <ThemeProvider theme={theme}>
         <BrowserRouter>
-          <HandleApiResponse
-            loading={loading}
-            error={error}
-            useModal
-            loadingText="Loading..."
-          >
-            <Header feed={currentFeed} />
-            <MainContentWrapper>
-              <Switch>
-                <Route exact path="/">
-                  <HomePage feed={currentFeed} />
-                </Route>
-                <Route exact path="/:feed/prospects/">
-                  <ProspectsListPage feed={currentFeed} />
-                </Route>
-                <Route
-                  exact
-                  path="/:feed/prospects/(snoozed|approved|rejected)/"
-                >
-                  <ProspectsListPage feed={currentFeed} />
-                </Route>
-                <Route path="/:feed/prospects/article/add/">
-                  <AddStoryPage />
-                </Route>
-                <Route path="/:feed/newtab/">
-                  <NewTabLivePage />
-                </Route>
-              </Switch>
-            </MainContentWrapper>
-          </HandleApiResponse>
+          {!data && (
+            <HandleApiResponse
+              loading={loading}
+              error={error}
+              useModal
+              loadingText="Loading..."
+            />
+          )}
+          {data && (
+            <>
+              <Header feed={currentFeed} />
+              <MainContentWrapper>
+                <Switch>
+                  <Route exact path="/">
+                    <HomePage feed={currentFeed} />
+                  </Route>
+                  <Route exact path="/:feed/prospects/">
+                    <ProspectsPage feed={currentFeed} />
+                  </Route>
+                  <Route
+                    exact
+                    path="/:feed/prospects/(snoozed|approved|rejected)/"
+                  >
+                    <ProspectsPage feed={currentFeed} />
+                  </Route>
+                  <Route path="/:feed/prospects/article/add/">
+                    <AddStoryPage />
+                  </Route>
+                  <Route path="/:feed/newtab/">
+                    <NewTabPage />
+                  </Route>
+                </Switch>
+              </MainContentWrapper>
+            </>
+          )}
         </BrowserRouter>
       </ThemeProvider>
     </ApolloProvider>

--- a/src/components/AddStory/AddStory.tsx
+++ b/src/components/AddStory/AddStory.tsx
@@ -26,7 +26,7 @@ export const AddStory = (): JSX.Element => {
   };
 
   return (
-    <main>
+    <>
       <Grid container spacing={3}>
         <Grid item xs={8}>
           <Typography variant="h4" component="h1" align="left">
@@ -59,6 +59,6 @@ export const AddStory = (): JSX.Element => {
           </Button>
         </Box>
       </form>
-    </main>
+    </>
   );
 };

--- a/src/components/Chip/Chip.test.tsx
+++ b/src/components/Chip/Chip.test.tsx
@@ -4,8 +4,8 @@ import { Chip } from './Chip';
 
 describe('The Chip component', () => {
   it('renders successfully', () => {
-    render(<Chip label="168" color="default" />);
+    render(<Chip label="48" color="default" />);
 
-    expect(screen.getByText('168')).toBeInTheDocument();
+    expect(screen.getByText('48')).toBeInTheDocument();
   });
 });

--- a/src/components/HandleApiResponse/HandleApiResponse.test.tsx
+++ b/src/components/HandleApiResponse/HandleApiResponse.test.tsx
@@ -11,15 +11,13 @@ describe('The HandleApiResponse component', () => {
         loading={true}
         loadingText="Loading data, please wait..."
         error={undefined}
-      >
-        <h1>Hello World!</h1>
-      </HandleApiResponse>
+      />
     );
 
     expect(screen.getByText(/^loading data/i)).toBeInTheDocument();
   });
 
-  it('renders an error if call to API has failed', () => {
+  it('renders an error if the call to the API has failed', () => {
     render(
       <HandleApiResponse
         loading={false}
@@ -29,9 +27,7 @@ describe('The HandleApiResponse component', () => {
             networkError: new Error('Server not found.'),
           })
         }
-      >
-        <h1>Hello World!</h1>
-      </HandleApiResponse>
+      />
     );
 
     // error messages
@@ -39,13 +35,11 @@ describe('The HandleApiResponse component', () => {
     expect(screen.getByText(/server not found/i)).toBeInTheDocument();
   });
 
-  it('renders children elements if API call is successful', () => {
-    render(
-      <HandleApiResponse loading={false} error={undefined}>
-        <h1>Hello World!</h1>
-      </HandleApiResponse>
+  it('renders nothing if the API call is successful', () => {
+    const { container } = render(
+      <HandleApiResponse loading={false} error={undefined} />
     );
 
-    expect(screen.getByText(/hello world/i)).toBeInTheDocument();
+    expect(container).toBeEmpty();
   });
 });

--- a/src/components/HandleApiResponse/HandleApiResponse.tsx
+++ b/src/components/HandleApiResponse/HandleApiResponse.tsx
@@ -40,33 +40,20 @@ interface HandleApiResponseProps {
    * A message to show to the waiting user alongside the loading icon
    */
   loadingText?: string;
-
-  /**
-   * Hand over to children components to display data once it
-   * is successfully retrieved
-   */
-  children: JSX.Element | JSX.Element[];
 }
 
 /**
- * A wrapper component that cycles through the various states
- * of the API response before handing over to child components to display
- * the retrieved data.
+ * A wrapper component that displays a loading component while the API call
+ * is in progress and any errors if the API call was unsuccessful.
  *
  * @param props
  */
 export const HandleApiResponse: React.FC<HandleApiResponseProps> = (
   props
-): JSX.Element => {
+): JSX.Element | null => {
   const classes = useStyles();
 
-  const {
-    loading,
-    error,
-    useModal = false,
-    loadingText = '',
-    children,
-  } = props;
+  const { loading, error, useModal = false, loadingText = '' } = props;
 
   if (loading) {
     return useModal ? (
@@ -114,5 +101,5 @@ export const HandleApiResponse: React.FC<HandleApiResponseProps> = (
     );
   }
 
-  return <>{children}</>;
+  return null;
 };

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -89,7 +89,7 @@ export const Header: React.FC<HeaderProps> = (props): JSX.Element => {
   }
 
   /* Keep track of active tabs */
-  const [value, setValue] = useState(selectedTab);
+  const [value, setValue] = useState<number | false>(selectedTab);
   const handleChange = (
     event: React.ChangeEvent<unknown>,
     newValue: number

--- a/src/components/LoginForm/LoginForm.tsx
+++ b/src/components/LoginForm/LoginForm.tsx
@@ -14,8 +14,8 @@ const useStyles = makeStyles(() =>
 export const LoginForm: React.FC = () => {
   const classes = useStyles();
 
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
+  const [email, setEmail] = useState<string>('');
+  const [password, setPassword] = useState<string>('');
 
   const handleEmail = (event: React.ChangeEvent<HTMLInputElement>) => {
     // TODO: add validation

--- a/src/components/Tab/Tab.test.tsx
+++ b/src/components/Tab/Tab.test.tsx
@@ -9,7 +9,7 @@ describe('The Tab component', () => {
       <MemoryRouter initialEntries={[`/en-US/newtab/`]}>
         <Tab
           label="Live"
-          count={222}
+          count={22}
           value="/en-US/newtab/live/"
           to="/en-US/newtab/live"
         />
@@ -20,6 +20,6 @@ describe('The Tab component', () => {
 
     expect(tab).toBeInTheDocument();
     expect(tab).toHaveTextContent('Live');
-    expect(within(tab).getByText('222')).toBeInTheDocument();
+    expect(within(tab).getByText('22')).toBeInTheDocument();
   });
 });

--- a/src/components/TabLink/TabLink.test.tsx
+++ b/src/components/TabLink/TabLink.test.tsx
@@ -22,13 +22,26 @@ describe('The TabLink component', () => {
   it('renders with article count', () => {
     render(
       <MemoryRouter>
-        <TabLink count={222} tabSelected to="/any/path/">
+        <TabLink count={22} tabSelected to="/any/path/">
           Tab title
         </TabLink>
       </MemoryRouter>
     );
 
     const tabLink = screen.getByRole('link');
-    expect(within(tabLink).getByText('222')).toBeInTheDocument();
+    expect(within(tabLink).getByText('22')).toBeInTheDocument();
+  });
+
+  it('renders with article count that is larger than 50', () => {
+    render(
+      <MemoryRouter>
+        <TabLink count={57} tabSelected to="/any/path/">
+          Tab title
+        </TabLink>
+      </MemoryRouter>
+    );
+
+    const tabLink = screen.getByRole('link');
+    expect(within(tabLink).getByText('50+')).toBeInTheDocument();
   });
 });

--- a/src/components/TabLink/TabLink.tsx
+++ b/src/components/TabLink/TabLink.tsx
@@ -30,9 +30,9 @@ export const TabLink = React.forwardRef<
     // workaround to make sure the chip on the active tab is highlighted.
     const color = tabSelected ? 'primary' : 'default';
 
-    // don't show the exact number of articles if there are more than
-    // a thousand of them.
-    const chipLabel = count && count > 999 ? '999+' : count;
+    // don't show the exact number of articles if there is more
+    // than a page's worth (50+)
+    const chipLabel = count && count > 50 ? '50+' : count;
 
     return (
       <Link {...otherProps} ref={ref}>

--- a/src/components/TabNavigation/TabNavigation.test.tsx
+++ b/src/components/TabNavigation/TabNavigation.test.tsx
@@ -2,49 +2,59 @@ import React from 'react';
 import { render, screen, within } from '@testing-library/react';
 import { TabNavigation } from './TabNavigation';
 import { Tab } from '../Tab/Tab';
-import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 
 describe('The TabNavigation component', () => {
-  let tabNavigation: any;
-  let tabs: any;
+  it('renders successfully with the first tab selected by default', () => {
+    const activeTab = '/de-DE/live/';
 
-  beforeEach(() => {
     render(
-      <MemoryRouter initialEntries={[`/de-DE/live/`]}>
-        <TabNavigation value="live" onChange={() => true}>
-          <Tab label="Live" count={222} value="live" to="/de-DE/live/" />
+      <MemoryRouter initialEntries={[activeTab]}>
+        <TabNavigation value={activeTab} onChange={() => true}>
+          <Tab label="Live" count={222} value={activeTab} to={activeTab} />
           <Tab
             label="Scheduled"
             count={333}
-            value="scheduled"
+            value="/de-DE/scheduled/"
             to="/de-DE/scheduled/"
           />
         </TabNavigation>
       </MemoryRouter>
     );
-    tabNavigation = screen.getByRole('tablist');
-    tabs = within(tabNavigation).getAllByRole('tab');
-  });
+    const tabNavigation = screen.getByRole('tablist');
+    const tabs = within(tabNavigation).getAllByRole('tab');
 
-  it('renders successfully', () => {
     expect(tabNavigation).toBeInTheDocument();
     expect(tabs.length).toEqual(2);
 
-    tabs.forEach((tab: HTMLButtonElement) => {
+    tabs.forEach((tab: HTMLElement) => {
       expect(tab).toBeInTheDocument();
     });
-  });
 
-  it('shows the first tab in the foreground by default', () => {
     expect(tabs[0].getAttribute('aria-selected')).toEqual('true');
     expect(tabs[1].getAttribute('aria-selected')).toEqual('false');
   });
 
-  xit('shows selected tab in the foreground', () => {
-    expect(tabs[0].getAttribute('aria-selected')).toEqual('true');
+  it('shows selected tab in the foreground', () => {
+    // second tab
+    const activeTab = '/de-DE/scheduled/';
 
-    userEvent.click(tabs[1]);
+    render(
+      <MemoryRouter initialEntries={[activeTab]}>
+        <TabNavigation value={activeTab} onChange={() => true}>
+          <Tab
+            label="Live"
+            count={222}
+            value="/de-DE/live/"
+            to="/de-DE/live/"
+          />
+          <Tab label="Scheduled" count={333} value={activeTab} to={activeTab} />
+        </TabNavigation>
+      </MemoryRouter>
+    );
+
+    const tabNavigation = screen.getByRole('tablist');
+    const tabs = within(tabNavigation).getAllByRole('tab');
 
     expect(tabs[1].getAttribute('aria-selected')).toEqual('true');
     expect(tabs[0].getAttribute('aria-selected')).toEqual('false');

--- a/src/pages/NewTabPage/NewTabPage.tsx
+++ b/src/pages/NewTabPage/NewTabPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Typography } from '@material-ui/core';
 
-export const NewTabLivePage = (): JSX.Element => {
+export const NewTabPage = (): JSX.Element => {
   return (
     <Typography variant="h4" component="h1" align="left">
       Here be dragons (New Tab)

--- a/src/pages/ProspectsPage/ProspectsPage.test.tsx
+++ b/src/pages/ProspectsPage/ProspectsPage.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { Router } from 'react-router';
+import { createMemoryHistory } from 'history';
+import { MockedProvider } from '@apollo/client/testing';
+import { render, screen, act, within } from '@testing-library/react';
+
+import { ProspectsPage } from './ProspectsPage';
+import { Feed } from '../../services/types/Feed';
+import {
+  getPendingProspects,
+  ProspectData,
+  ProspectVariables,
+  RECORDS_ON_PAGE,
+} from '../../services/queries/getPendingProspects';
+
+describe('The Prospects page', () => {
+  let mockFeed: Feed;
+
+  beforeEach(() => {
+    mockFeed = { id: 'abc', name: 'en-US' };
+  });
+
+  xit('renders with four tabs', () => {
+    const history = createMemoryHistory({
+      initialEntries: ['/en-US/prospects/'],
+    });
+
+    render(
+      <MockedProvider>
+        <Router history={history}>
+          <ProspectsPage feed={mockFeed} />
+        </Router>
+      </MockedProvider>
+    );
+
+    const tabNavigation = screen.getByRole('tablist');
+    const tabs = within(tabNavigation).getAllByRole('tab');
+
+    expect(tabNavigation).toBeInTheDocument();
+    expect(tabs.length).toEqual(4);
+  });
+
+  xit('shows pending prospects on the default Prospects tab', async () => {
+    const mocks = [
+      {
+        request: {
+          query: getPendingProspects,
+          variables: {
+            feedId: mockFeed.id,
+            limit: RECORDS_ON_PAGE,
+            nextToken: null,
+          } as ProspectVariables,
+        },
+        result: {
+          data: {
+            listProspects: {
+              items: [
+                {
+                  id: 'abc-123',
+                  altText: 'This is an image',
+                  author: 'Test author',
+                  category: 'Health',
+                  excerpt: 'This is a short description',
+                  imageUrl: 'https://test.com/image.jpeg',
+                  publisher: 'Test publisher',
+                  source: 'Syndication',
+                  title: 'Test title',
+                  url: 'https://test.com/test-title/',
+                },
+                {
+                  id: 'cde-345',
+                  altText: 'This is an image 2',
+                  author: 'Test author 2',
+                  category: 'Art',
+                  excerpt: 'This is a short description 2',
+                  imageUrl: 'https://test.com/image2.jpeg',
+                  publisher: 'Test publisher 2',
+                  source: 'Syndication',
+                  title: 'Test title 2',
+                  url: 'https://test.com/test-title-2/',
+                },
+              ],
+              nextToken: 'abcdefg',
+            },
+          } as ProspectData,
+        },
+      },
+    ];
+
+    const history = createMemoryHistory({
+      initialEntries: ['/en-US/prospects/'],
+    });
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <Router history={history}>
+          <ProspectsPage feed={mockFeed} />
+        </Router>
+      </MockedProvider>
+    );
+
+    // wait for the mock API call to complete
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    const cardTitle = await screen.findByText('/test title/i');
+    console.log(cardTitle);
+    expect(cardTitle).toBeInTheDocument();
+  });
+});

--- a/src/services/queries/getPendingProspects.ts
+++ b/src/services/queries/getPendingProspects.ts
@@ -2,34 +2,27 @@ import { gql } from '@apollo/client';
 import { Prospect } from '../types/Prospect';
 import { ProspectData } from '../fragments/ProspectData';
 
-interface ProspectId {
-  id: string;
-}
+export const RECORDS_ON_PAGE = 50;
 
 export interface ProspectData {
-  total: { items: ProspectId[] };
-  listProspects: { items: Prospect[] };
+  listProspects: { items: Prospect[]; nextToken: string | null };
 }
 
 export interface ProspectVariables {
   feedId: string;
   limit: number;
+  nextToken: string | null;
 }
 
 /**
  * Get pending prospects for a given feed ID.
+ * TODO: filter out snoozed entries
  */
 export const getPendingProspects = gql`
-  query getPendingProspects($feedId: ID!, $limit: Int!) {
-    total: listProspects(
-      filter: { feedId: { eq: $feedId }, state: { eq: PENDING } }
-    ) {
-      items {
-        id
-      }
-    }
+  query getPendingProspects($feedId: ID!, $limit: Int!, $nextToken: String) {
     listProspects(
       limit: $limit
+      nextToken: $nextToken
       filter: { feedId: { eq: $feedId }, state: { eq: PENDING } }
     ) {
       items {


### PR DESCRIPTION
## Goal

Implement fixes and improvements to code noted at the most recent Zoom meeting.

## Implementation Decisions

- Show 50+ pill with article count on tabs as there is currently no way
to fetch record totals from the API

- Fix TabNavigation tests

- Fix constant page re-renders (HandleApiResponse was to blame)

- Future-proof prospects query (add 'nextToken' for pagination)

- Add types to useState() hooks

Note that a couple of tests have been added for the ProspectsPage component, but they are skipped for now as they do not yet work with several state changes inside the component.

@jpetto, you were very much justified in being suspicious of the HandleApiResponse component - it was the one that caused all the re-renders, as the `loading` state is triggered briefly even when Apollo fetches query results from the local cache. 

Please review this PR ahead of the others as I need the changes here to make sure the AddStory page works as intended, especially with regards to refreshing results on adding a new prospect. I will rebase that branch on this one for now and continue working there.