### PR TITLE
Replace fireEvent() calls with userEvent() ones in all tests

### DIFF
--- a/src/components/AddStory/AddStory.test.tsx
+++ b/src/components/AddStory/AddStory.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { AddStory } from './AddStory';
 
 describe('The AddStory component', () => {
@@ -33,10 +34,8 @@ describe('The AddStory component', () => {
 
     const input = screen.getByLabelText(/story url/i) as HTMLInputElement;
 
-    fireEvent.change(input, {
-      target: { value: testUrl },
-    });
-
+    userEvent.clear(input);
+    userEvent.type(input, testUrl);
     expect(input).toHaveValue(testUrl);
   });
 
@@ -46,7 +45,7 @@ describe('The AddStory component', () => {
     });
 
     await waitFor(() => {
-      fireEvent.submit(screen.getByRole('form'));
+      userEvent.click(screen.getByText(/parse/i));
     });
 
     expect(await screen.getByText(/please enter a url/i)).toBeInTheDocument();
@@ -61,13 +60,9 @@ describe('The AddStory component', () => {
     await waitFor(() => {
       const input = screen.getByLabelText(/story url/i) as HTMLInputElement;
 
-      fireEvent.input(input, {
-        target: {
-          value: 'test link',
-        },
-      });
-
-      fireEvent.submit(screen.getByRole('form'));
+      userEvent.clear(input);
+      userEvent.type(input, 'this is not a valid link');
+      userEvent.click(screen.getByText(/parse/i));
     });
 
     expect(
@@ -84,13 +79,9 @@ describe('The AddStory component', () => {
     await waitFor(() => {
       const input = screen.getByLabelText(/story url/i) as HTMLInputElement;
 
-      fireEvent.input(input, {
-        target: {
-          value: testUrl,
-        },
-      });
-
-      fireEvent.submit(screen.getByRole('form'));
+      userEvent.clear(input);
+      userEvent.type(input, testUrl);
+      userEvent.click(screen.getByText(/parse/i));
     });
 
     expect(screen.queryByText(/please enter a url/i)).not.toBeInTheDocument();

--- a/src/components/LoginForm/LoginForm.test.tsx
+++ b/src/components/LoginForm/LoginForm.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { LoginForm } from './LoginForm';
 
 describe('The LoginForm component', () => {
@@ -22,14 +23,12 @@ describe('The LoginForm component', () => {
     const testEmail = 'john.citizen@test.com';
     const testPassword = 'kittens';
 
-    fireEvent.change(email, {
-      target: { value: testEmail },
-    });
-    fireEvent.change(password, {
-      target: { value: testPassword },
-    });
-
+    userEvent.clear(email);
+    userEvent.type(email, testEmail);
     expect(email).toHaveValue(testEmail);
+
+    userEvent.clear(password);
+    userEvent.type(password, testPassword);
     expect(password).toHaveValue(testPassword);
   });
 });

--- a/src/pages/AddStoryPage/AddStoryPage.test.tsx
+++ b/src/pages/AddStoryPage/AddStoryPage.test.tsx
@@ -3,7 +3,8 @@ import { Router } from 'react-router';
 import { createMemoryHistory } from 'history';
 import { MockedProvider } from '@apollo/client/testing';
 import { ApolloError } from '@apollo/client';
-import { render, fireEvent, screen, act } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { AddStoryPage } from './AddStoryPage';
 import { Feed } from '../../services/types/Feed';
@@ -46,12 +47,11 @@ describe('The AddStory page', () => {
 
     // fill out the form
     const input = screen.getByLabelText(/story url/i) as HTMLInputElement;
-    fireEvent.change(input, {
-      target: { value: testUrl },
-    });
+    userEvent.clear(input);
+    userEvent.type(input, testUrl);
 
     // submit it
-    fireEvent.click(screen.getByText(/parse/i));
+    userEvent.click(screen.getByText(/parse/i));
 
     // wait for the API
     await act(async () => {
@@ -99,12 +99,11 @@ describe('The AddStory page', () => {
 
     // fill out the form
     const input = screen.getByLabelText(/story url/i) as HTMLInputElement;
-    fireEvent.change(input, {
-      target: { value: testUrl },
-    });
+    userEvent.clear(input);
+    userEvent.type(input, testUrl);
 
     // submit it
-    fireEvent.click(screen.getByText(/parse/i));
+    userEvent.click(screen.getByText(/parse/i));
 
     // wait for the API
     await act(async () => {
@@ -136,8 +135,7 @@ describe('The AddStory page', () => {
         </MockedProvider>
       );
 
-      const cancelButton = screen.getByText('Cancel');
-      fireEvent.click(cancelButton);
+      userEvent.click(screen.getByText('Cancel'));
 
       expect(history.location.pathname).toEqual('/en-US/prospects/');
     });
@@ -156,8 +154,7 @@ describe('The AddStory page', () => {
         </MockedProvider>
       );
 
-      const cancelButton = screen.getByText('Cancel');
-      fireEvent.click(cancelButton);
+      userEvent.click(screen.getByText('Cancel'));
 
       expect(history.location.pathname).toEqual('/');
     });


### PR DESCRIPTION
Following a recent upgrade of the testing libraries, all simulated user interactions in tests are now done with userEvent() calls which make tests more intuitive to write and easier to read.