### PR TITLE
Add data to Snoozed/Approved/Rejected tabs

### DIFF
--- a/local-api-server/generateData.js
+++ b/local-api-server/generateData.js
@@ -19,7 +19,7 @@ jsf.extend('faker', () => {
       // Note that some of the entries will have different states
       // (i.e. REJECTED, APPROVED), so only a handful will appear
       // in the Snoozed tab (PENDING state + snoozedUntil in the future)
-      return faker.random.arrayElement[(null, null, date.toISOString())];
+      return faker.random.arrayElement([null, null, Math.floor(+date / 1000)]);
     },
     imageUrl: () => {
       const random = Math.round(Math.random() * 1000);
@@ -106,7 +106,7 @@ const schema = {
           enum: ['PENDING', 'REJECTED', 'APPROVED'],
         },
         snoozedUntil: {
-          type: 'datetime',
+          type: 'integer',
           faker: 'custom.snoozedUntil',
         },
         url: {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -13,6 +13,10 @@ const useGetPendingProspects = process.env.REACT_APP_USE_POCKET_API
   ? awsAPI.useGetPendingProspects
   : localAPI.useGetPendingProspects;
 
+const useGetSnoozedProspects = localAPI.useGetSnoozedProspects;
+const useGetRejectedProspects = localAPI.useGetRejectedProspects;
+const useGetApprovedProspects = localAPI.useGetApprovedProspects;
+
 const useCreateProspectByUrl = process.env.REACT_APP_USE_POCKET_API
   ? awsAPI.useCreateProspectByUrl
   : awsAPI.useCreateProspectByUrl;
@@ -25,6 +29,9 @@ export {
   client,
   useGetCurrentFeed,
   useGetPendingProspects,
+  useGetSnoozedProspects,
+  useGetRejectedProspects,
+  useGetApprovedProspects,
   useCreateProspectByUrl,
   useApproveProspect,
 };

--- a/src/api/local/generatedTypes.ts
+++ b/src/api/local/generatedTypes.ts
@@ -603,7 +603,7 @@ export const GetRejectedProspectsDocument = gql`
     ) {
       ...ProspectData
     }
-    totals: allProspects(filter: { state: "PENDING", feed_id: $feedId }) {
+    totals: allProspects(filter: { state: "REJECTED", feed_id: $feedId }) {
       id
     }
   }

--- a/src/api/local/generatedTypes.ts
+++ b/src/api/local/generatedTypes.ts
@@ -76,19 +76,19 @@ export type Prospect = {
   feed_id: Scalars['ID'];
   url: Scalars['String'];
   title: Scalars['String'];
-  imageUrl: Scalars['String'];
-  sourceScore: Scalars['Float'];
-  sourceName: Scalars['String'];
   publisher: Scalars['String'];
-  author: Scalars['String'];
-  syndicationArticleId: Scalars['String'];
-  itemId: Scalars['String'];
-  topic: Scalars['String'];
-  state: Scalars['String'];
   excerpt: Scalars['String'];
-  snoozedUntil?: Maybe<Scalars['String']>;
+  state: Scalars['String'];
+  author: Scalars['String'];
+  sourceName: Scalars['String'];
+  imageUrl: Scalars['String'];
+  snoozedUntil?: Maybe<Scalars['Int']>;
+  syndicationArticleId: Scalars['String'];
   altText: Scalars['String'];
   createdAt: Scalars['String'];
+  itemId: Scalars['String'];
+  topic: Scalars['String'];
+  sourceScore: Scalars['Float'];
   updatedAt?: Maybe<Scalars['String']>;
   Feed?: Maybe<Feed>;
 };
@@ -112,20 +112,24 @@ export type ProspectFilter = {
   feed_id?: Maybe<Scalars['ID']>;
   url?: Maybe<Scalars['String']>;
   title?: Maybe<Scalars['String']>;
-  imageUrl?: Maybe<Scalars['String']>;
-  sourceScore?: Maybe<Scalars['Float']>;
-  sourceName?: Maybe<Scalars['String']>;
   publisher?: Maybe<Scalars['String']>;
-  author?: Maybe<Scalars['String']>;
-  syndicationArticleId?: Maybe<Scalars['String']>;
-  itemId?: Maybe<Scalars['String']>;
-  topic?: Maybe<Scalars['String']>;
-  state?: Maybe<Scalars['String']>;
   excerpt?: Maybe<Scalars['String']>;
-  snoozedUntil?: Maybe<Scalars['String']>;
+  state?: Maybe<Scalars['String']>;
+  author?: Maybe<Scalars['String']>;
+  sourceName?: Maybe<Scalars['String']>;
+  imageUrl?: Maybe<Scalars['String']>;
+  snoozedUntil?: Maybe<Scalars['Int']>;
+  syndicationArticleId?: Maybe<Scalars['String']>;
   altText?: Maybe<Scalars['String']>;
   createdAt?: Maybe<Scalars['String']>;
+  itemId?: Maybe<Scalars['String']>;
+  topic?: Maybe<Scalars['String']>;
+  sourceScore?: Maybe<Scalars['Float']>;
   updatedAt?: Maybe<Scalars['String']>;
+  snoozedUntil_lt?: Maybe<Scalars['Int']>;
+  snoozedUntil_lte?: Maybe<Scalars['Int']>;
+  snoozedUntil_gt?: Maybe<Scalars['Int']>;
+  snoozedUntil_gte?: Maybe<Scalars['Int']>;
   sourceScore_lt?: Maybe<Scalars['Float']>;
   sourceScore_lte?: Maybe<Scalars['Float']>;
   sourceScore_gt?: Maybe<Scalars['Float']>;
@@ -161,19 +165,19 @@ export type MutationCreateProspectArgs = {
   feed_id: Scalars['ID'];
   url: Scalars['String'];
   title: Scalars['String'];
-  imageUrl: Scalars['String'];
-  sourceScore: Scalars['Float'];
-  sourceName: Scalars['String'];
   publisher: Scalars['String'];
-  author: Scalars['String'];
-  syndicationArticleId: Scalars['String'];
-  itemId: Scalars['String'];
-  topic: Scalars['String'];
-  state: Scalars['String'];
   excerpt: Scalars['String'];
-  snoozedUntil?: Maybe<Scalars['String']>;
+  state: Scalars['String'];
+  author: Scalars['String'];
+  sourceName: Scalars['String'];
+  imageUrl: Scalars['String'];
+  snoozedUntil?: Maybe<Scalars['Int']>;
+  syndicationArticleId: Scalars['String'];
   altText: Scalars['String'];
   createdAt: Scalars['String'];
+  itemId: Scalars['String'];
+  topic: Scalars['String'];
+  sourceScore: Scalars['Float'];
   updatedAt?: Maybe<Scalars['String']>;
 };
 
@@ -182,19 +186,19 @@ export type MutationUpdateProspectArgs = {
   feed_id?: Maybe<Scalars['ID']>;
   url?: Maybe<Scalars['String']>;
   title?: Maybe<Scalars['String']>;
-  imageUrl?: Maybe<Scalars['String']>;
-  sourceScore?: Maybe<Scalars['Float']>;
-  sourceName?: Maybe<Scalars['String']>;
   publisher?: Maybe<Scalars['String']>;
-  author?: Maybe<Scalars['String']>;
-  syndicationArticleId?: Maybe<Scalars['String']>;
-  itemId?: Maybe<Scalars['String']>;
-  topic?: Maybe<Scalars['String']>;
-  state?: Maybe<Scalars['String']>;
   excerpt?: Maybe<Scalars['String']>;
-  snoozedUntil?: Maybe<Scalars['String']>;
+  state?: Maybe<Scalars['String']>;
+  author?: Maybe<Scalars['String']>;
+  sourceName?: Maybe<Scalars['String']>;
+  imageUrl?: Maybe<Scalars['String']>;
+  snoozedUntil?: Maybe<Scalars['Int']>;
+  syndicationArticleId?: Maybe<Scalars['String']>;
   altText?: Maybe<Scalars['String']>;
   createdAt?: Maybe<Scalars['String']>;
+  itemId?: Maybe<Scalars['String']>;
+  topic?: Maybe<Scalars['String']>;
+  sourceScore?: Maybe<Scalars['Float']>;
   updatedAt?: Maybe<Scalars['String']>;
 };
 
@@ -231,6 +235,21 @@ export type ApproveProspectMutation = { __typename?: 'Mutation' } & {
   data?: Maybe<{ __typename?: 'Prospect' } & ProspectDataFragment>;
 };
 
+export type GetApprovedProspectsQueryVariables = Exact<{
+  feedId: Scalars['ID'];
+  page: Scalars['Int'];
+  perPage: Scalars['Int'];
+}>;
+
+export type GetApprovedProspectsQuery = { __typename?: 'Query' } & {
+  allProspects?: Maybe<
+    Array<Maybe<{ __typename?: 'Prospect' } & ProspectDataFragment>>
+  >;
+  totals?: Maybe<
+    Array<Maybe<{ __typename?: 'Prospect' } & Pick<Prospect, 'id'>>>
+  >;
+};
+
 export type GetCurrentFeedQueryVariables = Exact<{
   name: Scalars['String'];
 }>;
@@ -248,6 +267,37 @@ export type GetPendingProspectsQueryVariables = Exact<{
 }>;
 
 export type GetPendingProspectsQuery = { __typename?: 'Query' } & {
+  allProspects?: Maybe<
+    Array<Maybe<{ __typename?: 'Prospect' } & ProspectDataFragment>>
+  >;
+  totals?: Maybe<
+    Array<Maybe<{ __typename?: 'Prospect' } & Pick<Prospect, 'id'>>>
+  >;
+};
+
+export type GetRejectedProspectsQueryVariables = Exact<{
+  feedId: Scalars['ID'];
+  page: Scalars['Int'];
+  perPage: Scalars['Int'];
+}>;
+
+export type GetRejectedProspectsQuery = { __typename?: 'Query' } & {
+  allProspects?: Maybe<
+    Array<Maybe<{ __typename?: 'Prospect' } & ProspectDataFragment>>
+  >;
+  totals?: Maybe<
+    Array<Maybe<{ __typename?: 'Prospect' } & Pick<Prospect, 'id'>>>
+  >;
+};
+
+export type GetSnoozedProspectsQueryVariables = Exact<{
+  feedId: Scalars['ID'];
+  page: Scalars['Int'];
+  perPage: Scalars['Int'];
+  currentTimestamp: Scalars['Int'];
+}>;
+
+export type GetSnoozedProspectsQuery = { __typename?: 'Query' } & {
   allProspects?: Maybe<
     Array<Maybe<{ __typename?: 'Prospect' } & ProspectDataFragment>>
   >;
@@ -348,6 +398,74 @@ export type ApproveProspectMutationResult = Apollo.MutationResult<ApproveProspec
 export type ApproveProspectMutationOptions = Apollo.BaseMutationOptions<
   ApproveProspectMutation,
   ApproveProspectMutationVariables
+>;
+export const GetApprovedProspectsDocument = gql`
+  query getApprovedProspects($feedId: ID!, $page: Int!, $perPage: Int!) {
+    allProspects(
+      filter: { state: "APPROVED", feed_id: $feedId }
+      page: $page
+      perPage: $perPage
+      sortField: "createdAt"
+      sortOrder: "DESC"
+    ) {
+      ...ProspectData
+    }
+    totals: allProspects(filter: { state: "APPROVED", feed_id: $feedId }) {
+      id
+    }
+  }
+  ${ProspectDataFragmentDoc}
+`;
+
+/**
+ * __useGetApprovedProspectsQuery__
+ *
+ * To run a query within a React component, call `useGetApprovedProspectsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetApprovedProspectsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetApprovedProspectsQuery({
+ *   variables: {
+ *      feedId: // value for 'feedId'
+ *      page: // value for 'page'
+ *      perPage: // value for 'perPage'
+ *   },
+ * });
+ */
+export function useGetApprovedProspectsQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetApprovedProspectsQuery,
+    GetApprovedProspectsQueryVariables
+  >
+) {
+  return Apollo.useQuery<
+    GetApprovedProspectsQuery,
+    GetApprovedProspectsQueryVariables
+  >(GetApprovedProspectsDocument, baseOptions);
+}
+export function useGetApprovedProspectsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetApprovedProspectsQuery,
+    GetApprovedProspectsQueryVariables
+  >
+) {
+  return Apollo.useLazyQuery<
+    GetApprovedProspectsQuery,
+    GetApprovedProspectsQueryVariables
+  >(GetApprovedProspectsDocument, baseOptions);
+}
+export type GetApprovedProspectsQueryHookResult = ReturnType<
+  typeof useGetApprovedProspectsQuery
+>;
+export type GetApprovedProspectsLazyQueryHookResult = ReturnType<
+  typeof useGetApprovedProspectsLazyQuery
+>;
+export type GetApprovedProspectsQueryResult = Apollo.QueryResult<
+  GetApprovedProspectsQuery,
+  GetApprovedProspectsQueryVariables
 >;
 export const GetCurrentFeedDocument = gql`
   query getCurrentFeed($name: String!) {
@@ -473,4 +591,156 @@ export type GetPendingProspectsLazyQueryHookResult = ReturnType<
 export type GetPendingProspectsQueryResult = Apollo.QueryResult<
   GetPendingProspectsQuery,
   GetPendingProspectsQueryVariables
+>;
+export const GetRejectedProspectsDocument = gql`
+  query getRejectedProspects($feedId: ID!, $page: Int!, $perPage: Int!) {
+    allProspects(
+      filter: { state: "REJECTED", feed_id: $feedId }
+      page: $page
+      perPage: $perPage
+      sortField: "createdAt"
+      sortOrder: "DESC"
+    ) {
+      ...ProspectData
+    }
+    totals: allProspects(filter: { state: "PENDING", feed_id: $feedId }) {
+      id
+    }
+  }
+  ${ProspectDataFragmentDoc}
+`;
+
+/**
+ * __useGetRejectedProspectsQuery__
+ *
+ * To run a query within a React component, call `useGetRejectedProspectsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetRejectedProspectsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetRejectedProspectsQuery({
+ *   variables: {
+ *      feedId: // value for 'feedId'
+ *      page: // value for 'page'
+ *      perPage: // value for 'perPage'
+ *   },
+ * });
+ */
+export function useGetRejectedProspectsQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetRejectedProspectsQuery,
+    GetRejectedProspectsQueryVariables
+  >
+) {
+  return Apollo.useQuery<
+    GetRejectedProspectsQuery,
+    GetRejectedProspectsQueryVariables
+  >(GetRejectedProspectsDocument, baseOptions);
+}
+export function useGetRejectedProspectsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetRejectedProspectsQuery,
+    GetRejectedProspectsQueryVariables
+  >
+) {
+  return Apollo.useLazyQuery<
+    GetRejectedProspectsQuery,
+    GetRejectedProspectsQueryVariables
+  >(GetRejectedProspectsDocument, baseOptions);
+}
+export type GetRejectedProspectsQueryHookResult = ReturnType<
+  typeof useGetRejectedProspectsQuery
+>;
+export type GetRejectedProspectsLazyQueryHookResult = ReturnType<
+  typeof useGetRejectedProspectsLazyQuery
+>;
+export type GetRejectedProspectsQueryResult = Apollo.QueryResult<
+  GetRejectedProspectsQuery,
+  GetRejectedProspectsQueryVariables
+>;
+export const GetSnoozedProspectsDocument = gql`
+  query getSnoozedProspects(
+    $feedId: ID!
+    $page: Int!
+    $perPage: Int!
+    $currentTimestamp: Int!
+  ) {
+    allProspects(
+      filter: {
+        state: "PENDING"
+        snoozedUntil_gte: $currentTimestamp
+        feed_id: $feedId
+      }
+      page: $page
+      perPage: $perPage
+      sortField: "createdAt"
+      sortOrder: "DESC"
+    ) {
+      ...ProspectData
+    }
+    totals: allProspects(
+      filter: {
+        state: "PENDING"
+        snoozedUntil_gte: $currentTimestamp
+        feed_id: $feedId
+      }
+    ) {
+      id
+    }
+  }
+  ${ProspectDataFragmentDoc}
+`;
+
+/**
+ * __useGetSnoozedProspectsQuery__
+ *
+ * To run a query within a React component, call `useGetSnoozedProspectsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetSnoozedProspectsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetSnoozedProspectsQuery({
+ *   variables: {
+ *      feedId: // value for 'feedId'
+ *      page: // value for 'page'
+ *      perPage: // value for 'perPage'
+ *      currentTimestamp: // value for 'currentTimestamp'
+ *   },
+ * });
+ */
+export function useGetSnoozedProspectsQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    GetSnoozedProspectsQuery,
+    GetSnoozedProspectsQueryVariables
+  >
+) {
+  return Apollo.useQuery<
+    GetSnoozedProspectsQuery,
+    GetSnoozedProspectsQueryVariables
+  >(GetSnoozedProspectsDocument, baseOptions);
+}
+export function useGetSnoozedProspectsLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    GetSnoozedProspectsQuery,
+    GetSnoozedProspectsQueryVariables
+  >
+) {
+  return Apollo.useLazyQuery<
+    GetSnoozedProspectsQuery,
+    GetSnoozedProspectsQueryVariables
+  >(GetSnoozedProspectsDocument, baseOptions);
+}
+export type GetSnoozedProspectsQueryHookResult = ReturnType<
+  typeof useGetSnoozedProspectsQuery
+>;
+export type GetSnoozedProspectsLazyQueryHookResult = ReturnType<
+  typeof useGetSnoozedProspectsLazyQuery
+>;
+export type GetSnoozedProspectsQueryResult = Apollo.QueryResult<
+  GetSnoozedProspectsQuery,
+  GetSnoozedProspectsQueryVariables
 >;

--- a/src/api/local/hooks/useGetApprovedProspects.ts
+++ b/src/api/local/hooks/useGetApprovedProspects.ts
@@ -4,20 +4,20 @@ import {
   ApiCallStates,
 } from '../../../models';
 import {
-  GetPendingProspectsQueryVariables,
-  useGetPendingProspectsQuery,
+  GetApprovedProspectsQueryVariables,
+  useGetApprovedProspectsQuery,
 } from '../generatedTypes';
 
-export const useGetPendingProspects = (
+export const useGetApprovedProspects = (
   vars: ProspectVariables
 ): ApiCallStates & ProspectListData => {
   const pageNumber = vars.page > 0 ? vars.page - 1 : 0;
   const variables = {
     ...vars,
     page: pageNumber,
-  } as GetPendingProspectsQueryVariables;
+  } as GetApprovedProspectsQueryVariables;
 
-  const { loading, error, data: result } = useGetPendingProspectsQuery({
+  const { loading, error, data: result } = useGetApprovedProspectsQuery({
     variables,
   });
 

--- a/src/api/local/hooks/useGetCurrentFeed.ts
+++ b/src/api/local/hooks/useGetCurrentFeed.ts
@@ -1,12 +1,10 @@
 import { client } from '../client';
 import { FeedVariables, FeedData } from '../../../models';
 import { useGetCurrentFeedQuery } from '../generatedTypes';
-import { getCurrentFeed } from '../queries/getCurrentFeed';
 import { useMemo } from 'react';
 
 export const useGetCurrentFeed = (vars: FeedVariables): FeedData => {
   const { loading, error, data: result } = useGetCurrentFeedQuery({
-    query: getCurrentFeed,
     variables: vars,
     client,
   });

--- a/src/api/local/hooks/useGetRejectedProspects.ts
+++ b/src/api/local/hooks/useGetRejectedProspects.ts
@@ -4,20 +4,20 @@ import {
   ApiCallStates,
 } from '../../../models';
 import {
-  GetPendingProspectsQueryVariables,
-  useGetPendingProspectsQuery,
+  GetRejectedProspectsQueryVariables,
+  useGetRejectedProspectsQuery,
 } from '../generatedTypes';
 
-export const useGetPendingProspects = (
+export const useGetRejectedProspects = (
   vars: ProspectVariables
 ): ApiCallStates & ProspectListData => {
   const pageNumber = vars.page > 0 ? vars.page - 1 : 0;
   const variables = {
     ...vars,
     page: pageNumber,
-  } as GetPendingProspectsQueryVariables;
+  } as GetRejectedProspectsQueryVariables;
 
-  const { loading, error, data: result } = useGetPendingProspectsQuery({
+  const { loading, error, data: result } = useGetRejectedProspectsQuery({
     variables,
   });
 

--- a/src/api/local/hooks/useGetSnoozedProspects.ts
+++ b/src/api/local/hooks/useGetSnoozedProspects.ts
@@ -4,20 +4,27 @@ import {
   ApiCallStates,
 } from '../../../models';
 import {
-  GetPendingProspectsQueryVariables,
-  useGetPendingProspectsQuery,
+  GetSnoozedProspectsQueryVariables,
+  useGetSnoozedProspectsQuery,
 } from '../generatedTypes';
 
-export const useGetPendingProspects = (
+export const useGetSnoozedProspects = (
   vars: ProspectVariables
 ): ApiCallStates & ProspectListData => {
   const pageNumber = vars.page > 0 ? vars.page - 1 : 0;
+
+  // Get current timestamp to be able to filter prospects
+  // to fetch only those entries with 'snoozedUntil' in the future
+  const date = new Date();
+  const currentTimestamp = Math.floor(+date / 1000);
+
   const variables = {
     ...vars,
     page: pageNumber,
-  } as GetPendingProspectsQueryVariables;
+    currentTimestamp,
+  } as GetSnoozedProspectsQueryVariables;
 
-  const { loading, error, data: result } = useGetPendingProspectsQuery({
+  const { loading, error, data: result } = useGetSnoozedProspectsQuery({
     variables,
   });
 

--- a/src/api/local/index.ts
+++ b/src/api/local/index.ts
@@ -1,4 +1,7 @@
 export { client } from './client';
 export { useGetCurrentFeed } from './hooks/useGetCurrentFeed';
 export { useGetPendingProspects } from './hooks/useGetPendingProspects';
+export { useGetSnoozedProspects } from './hooks/useGetSnoozedProspects';
+export { useGetApprovedProspects } from './hooks/useGetApprovedProspects';
+export { useGetRejectedProspects } from './hooks/useGetRejectedProspects';
 export { useApproveProspect } from './hooks/useApproveProspect';

--- a/src/api/local/queries/getApprovedProspects.ts
+++ b/src/api/local/queries/getApprovedProspects.ts
@@ -1,0 +1,22 @@
+import { gql } from '@apollo/client';
+import { ProspectData } from '../fragments/ProspectData';
+/**
+ * Get pending prospects for a given feed ID.
+ */
+export const getApprovedProspects = gql`
+  query getApprovedProspects($feedId: ID!, $page: Int!, $perPage: Int!) {
+    allProspects(
+      filter: { state: "APPROVED", feed_id: $feedId }
+      page: $page
+      perPage: $perPage
+      sortField: "createdAt"
+      sortOrder: "DESC"
+    ) {
+      ...ProspectData
+    }
+    totals: allProspects(filter: { state: "APPROVED", feed_id: $feedId }) {
+      id
+    }
+  }
+  ${ProspectData}
+`;

--- a/src/api/local/queries/getRejectedProspects.ts
+++ b/src/api/local/queries/getRejectedProspects.ts
@@ -14,7 +14,7 @@ export const getRejectedProspects = gql`
     ) {
       ...ProspectData
     }
-    totals: allProspects(filter: { state: "PENDING", feed_id: $feedId }) {
+    totals: allProspects(filter: { state: "REJECTED", feed_id: $feedId }) {
       id
     }
   }

--- a/src/api/local/queries/getRejectedProspects.ts
+++ b/src/api/local/queries/getRejectedProspects.ts
@@ -1,0 +1,22 @@
+import { gql } from '@apollo/client';
+import { ProspectData } from '../fragments/ProspectData';
+/**
+ * Get rejected prospects for a given feed ID.
+ */
+export const getRejectedProspects = gql`
+  query getRejectedProspects($feedId: ID!, $page: Int!, $perPage: Int!) {
+    allProspects(
+      filter: { state: "REJECTED", feed_id: $feedId }
+      page: $page
+      perPage: $perPage
+      sortField: "createdAt"
+      sortOrder: "DESC"
+    ) {
+      ...ProspectData
+    }
+    totals: allProspects(filter: { state: "PENDING", feed_id: $feedId }) {
+      id
+    }
+  }
+  ${ProspectData}
+`;

--- a/src/api/local/queries/getSnoozedProspects.ts
+++ b/src/api/local/queries/getSnoozedProspects.ts
@@ -1,0 +1,37 @@
+import { gql } from '@apollo/client';
+import { ProspectData } from '../fragments/ProspectData';
+/**
+ * Get snoozed prospects for a given feed ID.
+ */
+export const getSnoozedProspects = gql`
+  query getSnoozedProspects(
+    $feedId: ID!
+    $page: Int!
+    $perPage: Int!
+    $currentTimestamp: Int!
+  ) {
+    allProspects(
+      filter: {
+        state: "PENDING"
+        snoozedUntil_gte: $currentTimestamp
+        feed_id: $feedId
+      }
+      page: $page
+      perPage: $perPage
+      sortField: "createdAt"
+      sortOrder: "DESC"
+    ) {
+      ...ProspectData
+    }
+    totals: allProspects(
+      filter: {
+        state: "PENDING"
+        snoozedUntil_gte: $currentTimestamp
+        feed_id: $feedId
+      }
+    ) {
+      id
+    }
+  }
+  ${ProspectData}
+`;

--- a/src/components/TabLink/TabLink.tsx
+++ b/src/components/TabLink/TabLink.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { Link, LinkProps } from 'react-router-dom';
+import { makeStyles, createStyles } from '@material-ui/core/styles';
+import { CircularProgress } from '@material-ui/core';
 import { Chip } from '../';
+import { curationPalette } from '../../theme';
 
 interface TabLinkProps {
   /**
@@ -14,6 +17,14 @@ interface TabLinkProps {
   tabSelected: boolean;
 }
 
+const useStyles = makeStyles(() =>
+  createStyles({
+    spinner: {
+      color: curationPalette.white,
+    },
+  })
+);
+
 /**
  * Used for routing between various subpages available as tabs, i.e.
  * Prospects/Snoozed/Approved/Rejected. Optionally shows a Chip with
@@ -24,6 +35,7 @@ export const TabLink = React.forwardRef<
   LinkProps & TabLinkProps
 >(
   (props, ref): JSX.Element => {
+    const classes = useStyles();
     const { count, children, tabSelected, ...otherProps } = props;
     const showChip = !!(count && count > 0);
 
@@ -37,7 +49,17 @@ export const TabLink = React.forwardRef<
     return (
       <Link {...otherProps} ref={ref}>
         {children}
-        {showChip && <Chip label={chipLabel} size="small" color={color} />}
+        <Chip
+          label={
+            showChip ? (
+              chipLabel
+            ) : (
+              <CircularProgress size={14} className={classes.spinner} />
+            )
+          }
+          size="small"
+          color={color}
+        />
       </Link>
     );
   }

--- a/src/pages/ProspectsPage/ProspectsPage.tsx
+++ b/src/pages/ProspectsPage/ProspectsPage.tsx
@@ -9,7 +9,12 @@ import {
 } from '../../components';
 import { Feed, Prospect } from '../../models';
 import { RECORDS_ON_PAGE } from '../../constants';
-import { useGetPendingProspects } from '../../api';
+import {
+  useGetPendingProspects,
+  useGetSnoozedProspects,
+  useGetRejectedProspects,
+  useGetApprovedProspects,
+} from '../../api';
 
 /**
  * Prospects page
@@ -42,9 +47,49 @@ export const ProspectsPage = ({
   // set base path for tab links
   const basePath = `/${feed?.name}/prospects/`;
 
-  // prepare query for the first tab
-  const { loading, error, data: pendingProspects } = useGetPendingProspects({
-    feedId: feed?.id ?? 'none',
+  // set feed id (this should always be available)
+  const feedId = feed?.id ?? 'none';
+
+  // Load pending prospects
+  const {
+    loading: loadingPending,
+    error: errorPending,
+    data: pendingProspects,
+  } = useGetPendingProspects({
+    feedId,
+    page: 1,
+    perPage: RECORDS_ON_PAGE,
+  });
+
+  // Load snoozed prospects
+  const {
+    loading: loadingSnoozed,
+    error: errorSnoozed,
+    data: snoozedProspects,
+  } = useGetSnoozedProspects({
+    feedId,
+    page: 1,
+    perPage: RECORDS_ON_PAGE,
+  });
+
+  // Load snoozed prospects
+  const {
+    loading: loadingApproved,
+    error: errorApproved,
+    data: approvedProspects,
+  } = useGetApprovedProspects({
+    feedId,
+    page: 1,
+    perPage: RECORDS_ON_PAGE,
+  });
+
+  // Load rejected prospects
+  const {
+    loading: loadingRejected,
+    error: errorRejected,
+    data: rejectedProspects,
+  } = useGetRejectedProspects({
+    feedId,
     page: 1,
     perPage: RECORDS_ON_PAGE,
   });
@@ -59,27 +104,31 @@ export const ProspectsPage = ({
           to={basePath}
         />
         <Tab
+          count={snoozedProspects?.meta.totalResults}
           label="Snoozed"
           value={`${basePath}snoozed/`}
           to={`${basePath}snoozed/`}
         />
         <Tab
+          count={approvedProspects?.meta.totalResults}
           label="Approved"
           value={`${basePath}approved/`}
           to={`${basePath}approved/`}
         />
         <Tab
+          count={rejectedProspects?.meta.totalResults}
           label="Rejected"
           value={`${basePath}rejected/`}
           to={`${basePath}rejected/`}
         />
       </TabNavigation>
-      {!pendingProspects && (
-        <HandleApiResponse loading={loading} error={error} />
-      )}
-      {pendingProspects && (
-        <TabPanel heading="Prospects" value={value} index={basePath}>
-          {pendingProspects.data?.map((prospect: Prospect) => {
+
+      <TabPanel heading="Prospects" value={value} index={basePath}>
+        {!pendingProspects && (
+          <HandleApiResponse loading={loadingPending} error={errorPending} />
+        )}
+        {pendingProspects &&
+          pendingProspects.data?.map((prospect: Prospect) => {
             return (
               <Card
                 key={prospect.id}
@@ -88,19 +137,54 @@ export const ProspectsPage = ({
               />
             );
           })}
-        </TabPanel>
-      )}
+      </TabPanel>
 
       <TabPanel heading="Snoozed" value={value} index={`${basePath}snoozed/`}>
-        <p>Coming soon...</p>
+        {!snoozedProspects && (
+          <HandleApiResponse loading={loadingSnoozed} error={errorSnoozed} />
+        )}
+        {snoozedProspects &&
+          snoozedProspects.data?.map((prospect: Prospect) => {
+            return (
+              <Card
+                key={prospect.id}
+                prospect={prospect}
+                url={`${basePath}${prospect.id}/`}
+              />
+            );
+          })}
       </TabPanel>
 
       <TabPanel heading="Approved" value={value} index={`${basePath}approved/`}>
-        <p>Coming soon...</p>
+        {!approvedProspects && (
+          <HandleApiResponse loading={loadingApproved} error={errorApproved} />
+        )}
+        {approvedProspects &&
+          approvedProspects.data?.map((prospect: Prospect) => {
+            return (
+              <Card
+                key={prospect.id}
+                prospect={prospect}
+                url={`${basePath}${prospect.id}/`}
+              />
+            );
+          })}
       </TabPanel>
 
       <TabPanel heading="Rejected" value={value} index={`${basePath}rejected/`}>
-        <p>Coming soon...</p>
+        {!rejectedProspects && (
+          <HandleApiResponse loading={loadingRejected} error={errorRejected} />
+        )}
+        {rejectedProspects &&
+          rejectedProspects.data?.map((prospect: Prospect) => {
+            return (
+              <Card
+                key={prospect.id}
+                prospect={prospect}
+                url={`${basePath}${prospect.id}/`}
+              />
+            );
+          })}
       </TabPanel>
     </>
   );


### PR DESCRIPTION
- Updated Prospects page to load data on all four tabs.

- Updated Tab component to always render the chip for number of articles, but show a loading spinner while the API call is in progress so that renders and re-renders do not cause content to jump around on the page.

- Updated data generation script for the local API (snoozedUntil field is now a timestamp).

Note that I haven't updated tests for the Prospects page as there is unexpected (!) trickiness around testing custom hooks. There should be ways to increase test coverage, but for now the new calls to the local API are untested. Please note that some of the data has been changed so before testing the PR locally, you need to rerun `npm run api:generate-data` script.