### PR TITLE
Fix styling issue with "Topic" label on Edit & Approve form

### DIFF
--- a/src/components/EditAndApproveStory/EditAndApproveStory.tsx
+++ b/src/components/EditAndApproveStory/EditAndApproveStory.tsx
@@ -375,6 +375,7 @@ export const EditAndApproveStory: React.FC<EditAndApproveStoryProps> = (
             <Select
               native
               inputProps={{
+                name: 'topic',
                 id: 'topic',
               }}
               inputRef={register({
@@ -383,7 +384,7 @@ export const EditAndApproveStory: React.FC<EditAndApproveStoryProps> = (
                   message: 'Please choose a topic for this story',
                 },
               })}
-              name="topic"
+              label="Topic"
               value={prospect.topic ?? ''}
               variant="outlined"
               onChange={handleTopicChange}


### PR DESCRIPTION
This has bothered me for a while. The border around the select label was cutting through the shrunk label. Now fixed.

Before: 

![select-label-before](https://user-images.githubusercontent.com/22447785/107209347-c92f8b00-6a56-11eb-9fb2-daa68dc70f2e.png)

After: 

![select-label-after](https://user-images.githubusercontent.com/22447785/107209362-cdf43f00-6a56-11eb-98e1-418651dfac55.png)

