### PR TITLE
Add correct buttons and labels to prospect cards

### DIFF
--- a/src/components/Card/Card.test.tsx
+++ b/src/components/Card/Card.test.tsx
@@ -5,8 +5,11 @@ import { Prospect } from '../../models';
 import { MemoryRouter } from 'react-router-dom';
 
 describe('The Card component', () => {
-  it('renders with image', () => {
-    const prospect: Prospect = {
+  let prospect: Prospect;
+  let baseUrl: string;
+
+  beforeEach(() => {
+    prospect = {
       id: '12345',
       altText: 'Test alt text',
       author: 'Just An Author',
@@ -21,20 +24,90 @@ describe('The Card component', () => {
       url: 'https://cnn.com/any-random-title/234567/',
     };
 
+    baseUrl = '/en-US/prospects/123c-456b-789c/';
+  });
+
+  it('renders with image', () => {
     render(
       <MemoryRouter>
-        <Card prospect={prospect} url="/en-US/prospects/123c-456b-789c/" />
+        <Card prospect={prospect} type="pending" url={baseUrl} />
       </MemoryRouter>
     );
 
     const image = screen.getByAltText(prospect.altText);
     expect(image).toBeInTheDocument();
+  });
 
-    const buttons = screen.getAllByRole('button');
-    expect(buttons.length).toEqual(3);
+  it('renders correctly for Pending prospects', () => {
+    render(
+      <MemoryRouter>
+        <Card prospect={prospect} type="pending" url={baseUrl} />
+      </MemoryRouter>
+    );
 
-    buttons.forEach((button) => {
-      expect(button).toBeInTheDocument();
-    });
+    // buttons
+    expect(screen.getByText(/reject/i)).toBeInTheDocument();
+    expect(screen.getByText(/snooze/i)).toBeInTheDocument();
+    expect(screen.getByText(/edit & approve/i)).toBeInTheDocument();
+  });
+
+  it('renders correctly for Snoozed prospects', () => {
+    render(
+      <MemoryRouter>
+        <Card prospect={prospect} type="snoozed" url={baseUrl} />
+      </MemoryRouter>
+    );
+
+    // buttons
+    expect(screen.getByText(/reject/i)).toBeInTheDocument();
+    expect(screen.getByText(/edit & approve/i)).toBeInTheDocument();
+  });
+
+  it('renders correctly for Approved prospects', () => {
+    render(
+      <MemoryRouter>
+        <Card prospect={prospect} type="approved" url={baseUrl} />
+      </MemoryRouter>
+    );
+
+    // buttons
+    expect(screen.getByText(/reject/i)).toBeInTheDocument();
+    expect(screen.getByText(/snooze/i)).toBeInTheDocument();
+    expect(screen.getByText(/edit/i)).toBeInTheDocument();
+  });
+
+  it('renders correctly for Rejected prospects', () => {
+    render(
+      <MemoryRouter>
+        <Card prospect={prospect} type="rejected" url={baseUrl} />
+      </MemoryRouter>
+    );
+
+    // buttons
+    expect(screen.getByText(/snooze/i)).toBeInTheDocument();
+  });
+
+  it('renders correctly for Live prospects', () => {
+    render(
+      <MemoryRouter>
+        <Card prospect={prospect} type="live" url={baseUrl} />
+      </MemoryRouter>
+    );
+
+    // buttons
+    expect(screen.getByText(/remove/i)).toBeInTheDocument();
+    expect(screen.getByText(/edit/i)).toBeInTheDocument();
+  });
+
+  it('renders correctly for Scheduled prospects', () => {
+    render(
+      <MemoryRouter>
+        <Card prospect={prospect} type="scheduled" url={baseUrl} />
+      </MemoryRouter>
+    );
+
+    // buttons
+    expect(screen.getByText(/remove/i)).toBeInTheDocument();
+    expect(screen.getByText(/edit/i)).toBeInTheDocument();
   });
 });

--- a/src/components/CardText/CardText.test.tsx
+++ b/src/components/CardText/CardText.test.tsx
@@ -11,6 +11,8 @@ describe('The CardText component', () => {
       title: 'Test title',
       excerpt:
         "This is a test string that represents a short description of the article's contents.",
+      label: 'Approved',
+      labelColor: 'primary',
     };
 
     render(<CardText {...expectedProps} />);
@@ -26,5 +28,6 @@ describe('The CardText component', () => {
     expect(screen.getByText(/test string/i)).toHaveTextContent(
       expectedProps.excerpt
     );
+    expect(screen.getByText(/approved/i)).toBeInTheDocument();
   });
 });

--- a/src/components/CardText/CardText.tsx
+++ b/src/components/CardText/CardText.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { CardContent, Typography } from '@material-ui/core';
+import { CardContent, Chip, Typography } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -15,6 +14,11 @@ const useStyles = makeStyles((theme: Theme) => ({
   url: {
     color: theme.palette.grey[900],
     textDecoration: 'none',
+  },
+  chip: {
+    fontWeight: 'bold',
+    marginRight: '0.375rem',
+    textTransform: 'capitalize',
   },
 }));
 
@@ -43,6 +47,17 @@ export interface CardTextProps {
    * A short summary of the story
    */
   excerpt: string;
+
+  /**
+   * Which label to display alongside other data for different types of prospects,
+   * i.e. "Rejected", "Snoozed", "Live".
+   */
+  label: string | null;
+
+  /**
+   * What styles to use for the label.
+   */
+  labelColor: 'primary' | 'secondary' | 'default';
 }
 
 /**
@@ -52,7 +67,7 @@ export interface CardTextProps {
  * @returns JSX.Element The rendered card
  */
 export const CardText: React.FC<CardTextProps> = (props): JSX.Element => {
-  const { publisher, author, url, title, excerpt } = props;
+  const { publisher, author, url, title, excerpt, label, labelColor } = props;
   const classes = useStyles();
 
   return (
@@ -68,12 +83,20 @@ export const CardText: React.FC<CardTextProps> = (props): JSX.Element => {
         </a>
       </Typography>
       <Typography
-        component="p"
+        component="div"
         align="left"
         color="textSecondary"
         display="block"
         gutterBottom
       >
+        {label && (
+          <Chip
+            className={classes.chip}
+            color={labelColor}
+            size="small"
+            label={label}
+          />
+        )}
         <Typography variant="caption" component="span">
           {publisher}
         </Typography>{' '}
@@ -87,12 +110,4 @@ export const CardText: React.FC<CardTextProps> = (props): JSX.Element => {
       </Typography>
     </CardContent>
   );
-};
-
-CardText.propTypes = {
-  publisher: PropTypes.string.isRequired,
-  author: PropTypes.string.isRequired,
-  url: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired,
-  excerpt: PropTypes.string.isRequired,
 };

--- a/src/pages/ProspectsPage/ProspectsPage.tsx
+++ b/src/pages/ProspectsPage/ProspectsPage.tsx
@@ -133,6 +133,7 @@ export const ProspectsPage = ({
               <Card
                 key={prospect.id}
                 prospect={prospect}
+                type="pending"
                 url={`${basePath}${prospect.id}/`}
               />
             );
@@ -149,6 +150,7 @@ export const ProspectsPage = ({
               <Card
                 key={prospect.id}
                 prospect={prospect}
+                type="snoozed"
                 url={`${basePath}${prospect.id}/`}
               />
             );
@@ -165,6 +167,7 @@ export const ProspectsPage = ({
               <Card
                 key={prospect.id}
                 prospect={prospect}
+                type="approved"
                 url={`${basePath}${prospect.id}/`}
               />
             );
@@ -181,6 +184,7 @@ export const ProspectsPage = ({
               <Card
                 key={prospect.id}
                 prospect={prospect}
+                type="rejected"
                 url={`${basePath}${prospect.id}/`}
               />
             );


### PR DESCRIPTION
## Goal

Update Prospects tabs so that each view shows customized cards with the correct buttons and labels.

- Each Prospects tab now shows the appropriate buttons (these are not yet wired to anything).

- All tabs except the default ("Pending") tab show prospects with labels ("Rejected", "Approved", etc.) as noted in the "Frontend Questions" document.

- Card component has been reworked to be mobile-friendly and match Figma comps.
 
## Implementation Decisions

As noted in the "Frontend Questions" document, I have dropped the "Edit & Approve" button from the "Rejected" tab. 

Labels are green (primary color) for Approved/Live/Scheduled prospects, brick red for Rejected prospects and default grey for Snoozed prospects.

In desktop view, thumbnail images now take up ~33% of the available width rather than 30% they used to be - instead of custom styles, I'm using MUI grids and this also seems a closer match for Figma comps.

Also, I took out the unnecessary URLs out of the buttons that should just perform a mutation without redirecting the user anywhere - this solves the flicker of a URL change noted by @kkyeboah in a recent review.