### PR TITLE
Update the data generation script for local API

### DIFF
--- a/local-api-server/generateData.js
+++ b/local-api-server/generateData.js
@@ -178,9 +178,15 @@ const schema = {
 };
 
 jsf.resolve(schema).then((data) => {
-  console.log('Writing to db.json...');
-
   const path = `${__dirname}/db.json`;
+  console.log('Generating new data...');
+
+  // Delete the previous db.json file if it exists
+  // Truncating it below when overwriting is not enough. Why?
+  // But this is better than the blank screen of death
+  fs.unlink(path, (error) => {
+    if (error) throw error;
+  });
 
   fs.writeFile(
     path,
@@ -188,17 +194,16 @@ jsf.resolve(schema).then((data) => {
     // Make sure the file is writable so that changes made on the frontend persist.
     // Note that it's still not enough - something else is needed to get it to work.
     { mode: 0o666 },
-    function (err) {
-      if (err) {
-        console.error(err);
-      } else {
-        // And make sure it's writable on Linux as well
-        // (see https://github.com/nodejs/node/issues/1104)
-        fs.chmod(path, 0o666, (error) => {
-          console.log('Updated file permissions.');
-        });
-        console.log('Created file.');
-      }
+    function (error) {
+      if (error) throw error;
+
+      // And make sure it's writable on Linux as well
+      // (see https://github.com/nodejs/node/issues/1104)
+      fs.chmod(path, 0o666, (error) => {
+        console.log(
+          'Done.\n\033[1mRun `npm run api:start` to start using the local API server'
+        );
+      });
     }
   );
 });


### PR DESCRIPTION
## Goal

Reduce the frequency of the annoying blank screen issue.

## Implementation Decisions

Delete `db.json` file before overwriting it with new data as truncating it is not enough if schema has been updated - the frontend app shows a blank screen even after following the steps in the troubleshooting section.

Improve logging messages to console, add a helpful hint with a reminder which command to run next.

NB: marking it as draft for now as it will probably have merge conflicts once #125 is in.